### PR TITLE
Fixture for tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,8 +7,10 @@ libraryDependencies ++= Seq(
   "org.antlr" % "antlr4-runtime" % "4.5.4",
   "io.shiftleft" % "codepropertygraph" % cpgVersion,
   "io.shiftleft" % "codepropertygraph-protos" % cpgVersion,
+  "io.shiftleft" % "cpgloader-tinkergraph" % cpgVersion,
   "com.novocode" % "junit-interface" % "0.11" % Test,
-  "junit" % "junit" % "4.12" % Test
+  "junit" % "junit" % "4.12" % Test,
+   "org.scalatest" %% "scalatest" % "3.0.3" % Test
 )
 
 // uncomment if you want to use a cpg version that has *just* been released

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/FileWalkerCallbacks.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/FileWalkerCallbacks.java
@@ -2,6 +2,7 @@ package io.shiftleft.fuzzyc2cpg;
 
 import io.shiftleft.fuzzyc2cpg.ast.walking.AstWalker;
 import io.shiftleft.fuzzyc2cpg.filewalker.SourceFileListener;
+import io.shiftleft.fuzzyc2cpg.outputmodules.OutputModule;
 import io.shiftleft.fuzzyc2cpg.parser.ModuleParser;
 import io.shiftleft.fuzzyc2cpg.parser.modules.AntlrCModuleParserDriver;
 import io.shiftleft.proto.cpg.Cpg.CpgStruct.Edge;
@@ -22,6 +23,11 @@ class FileWalkerCallbacks extends SourceFileListener {
 
   StructureCpg structureCpg;
   AstWalker astWalker;
+  OutputModule outputModule;
+
+  public FileWalkerCallbacks(OutputModule outputModule) {
+    this.outputModule = outputModule;
+  }
 
   @Override
   public void initialize() {
@@ -52,6 +58,7 @@ class FileWalkerCallbacks extends SourceFileListener {
 
   private void initializeWalker() {
     astWalker = new AstWalker();
+    astWalker.setOutputModule(outputModule);
     astWalker.setStructureCpg(structureCpg);
   }
 
@@ -113,7 +120,7 @@ class FileWalkerCallbacks extends SourceFileListener {
     String outputFilename = Paths
         .get(Config.outputDirectory, "structural-cpg.proto")
         .toString();
-    new ProtoOutputModule().output(structureCpg.getCpg(), outputFilename);
+    outputModule.output(structureCpg.getCpg(), outputFilename);
   }
 
 }

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/FunctionDefHandler.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/FunctionDefHandler.java
@@ -20,6 +20,7 @@ import io.shiftleft.fuzzyc2cpg.cfg.nodes.CfgExceptionNode;
 import io.shiftleft.fuzzyc2cpg.cfg.nodes.CfgExitNode;
 import io.shiftleft.fuzzyc2cpg.cfg.nodes.CfgNode;
 import io.shiftleft.fuzzyc2cpg.cfg.nodes.InfiniteForNode;
+import io.shiftleft.fuzzyc2cpg.outputmodules.OutputModule;
 import io.shiftleft.proto.cpg.Cpg.CpgStruct;
 import io.shiftleft.proto.cpg.Cpg.CpgStruct.Edge.EdgeType;
 import io.shiftleft.proto.cpg.Cpg.CpgStruct.Node;
@@ -39,10 +40,12 @@ public class FunctionDefHandler {
   private CFG cfg;
   Node methodNode;
   CpgStruct.Builder bodyCpg;
+  private final OutputModule outputModule;
 
-  public FunctionDefHandler(StructureCpg structureCpg) {
+  public FunctionDefHandler(StructureCpg structureCpg, OutputModule outputModule) {
     this.structureCpg = structureCpg;
     this.bodyCpg = CpgStruct.newBuilder();
+    this.outputModule = outputModule;
   }
 
   public void handle(FunctionDefBase ast) {
@@ -50,7 +53,7 @@ public class FunctionDefHandler {
     addMethodStubToStructureCpg(ast);
     addMethodBodyCpg(cfg);
     String outputFilename = generateOutputFilename(ast);
-    new ProtoOutputModule().output(bodyCpg, outputFilename);
+    outputModule.output(bodyCpg, outputFilename);
   }
 
   private String generateOutputFilename(FunctionDefBase ast) {

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/Fuzzyc2Cpg.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/Fuzzyc2Cpg.java
@@ -1,0 +1,50 @@
+package io.shiftleft.fuzzyc2cpg;
+
+import io.shiftleft.fuzzyc2cpg.filewalker.OrderedWalker;
+import io.shiftleft.fuzzyc2cpg.filewalker.SourceFileWalker;
+import io.shiftleft.fuzzyc2cpg.outputmodules.OutputModule;
+import java.io.File;
+import java.io.IOException;
+
+public class Fuzzyc2Cpg {
+
+  private FileWalkerCallbacks parser;
+  private SourceFileWalker sourceFileWalker = new OrderedWalker();
+
+  public Fuzzyc2Cpg(OutputModule outputModule) {
+    setupParser(outputModule);
+  }
+
+  /**
+   * Create a new parser and register it as a listener
+   * for the source file walker, such that it can be
+   * called for each source file.
+   */
+  private void setupParser(OutputModule outputModule) {
+    parser = new FileWalkerCallbacks(outputModule);
+    parser.initialize();
+    sourceFileWalker.addListener(parser);
+  }
+
+  public void runAndOutput(String [] fileAndDirNames) {
+    createOutputDirectory();
+    walkCodebase(fileAndDirNames);
+  }
+
+  private void createOutputDirectory() {
+    new File(
+        Config.outputDirectory
+    ).mkdirs();
+  }
+
+  private void walkCodebase(String[] fileAndDirNames) {
+    try {
+      sourceFileWalker.walk(fileAndDirNames);
+    } catch (IOException err) {
+      System.err.println("Error walking source files: " + err.getMessage());
+    } finally {
+      parser.shutdown();
+    }
+  }
+
+}

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/Main.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/Main.java
@@ -1,48 +1,13 @@
 package io.shiftleft.fuzzyc2cpg;
 
-import io.shiftleft.fuzzyc2cpg.filewalker.OrderedWalker;
-import io.shiftleft.fuzzyc2cpg.filewalker.SourceFileWalker;
-import java.io.File;
-import java.io.IOException;
+import io.shiftleft.fuzzyc2cpg.outputmodules.ProtoOutputModule;
 
 public class Main {
 
-  private static FileWalkerCallbacks parser;
-  private static SourceFileWalker sourceFileWalker = new OrderedWalker();
-
   public static void main(String[] args) {
-    setupParser();
-
     String[] fileAndDirNames = {"input"};
-    walkCodebase(fileAndDirNames);
-  }
-
-  /**
-   * Create a new parser and register it as a listener
-   * for the source file walker, such that it can be
-   * called for each source file.
-   * */
-  private static void setupParser() {
-    parser = new FileWalkerCallbacks();
-    parser.initialize();
-    createOutputDirectory();
-    sourceFileWalker.addListener(parser);
-  }
-
-  private static void createOutputDirectory() {
-    new File(
-        Config.outputDirectory
-    ).mkdirs();
-  }
-
-  private static void walkCodebase(String[] fileAndDirNames) {
-    try {
-      sourceFileWalker.walk(fileAndDirNames);
-    } catch (IOException err) {
-      System.err.println("Error walking source files: " + err.getMessage());
-    } finally {
-      parser.shutdown();
-    }
+    Fuzzyc2Cpg fuzzyc2Cpg = new Fuzzyc2Cpg(new ProtoOutputModule());
+    fuzzyc2Cpg.runAndOutput(fileAndDirNames);
   }
 
 }

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/ParserCallbacks.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/ParserCallbacks.java
@@ -4,15 +4,22 @@ import io.shiftleft.fuzzyc2cpg.ast.declarations.ClassDefStatement;
 import io.shiftleft.fuzzyc2cpg.ast.functionDef.FunctionDefBase;
 import io.shiftleft.fuzzyc2cpg.ast.statements.IdentifierDeclStatement;
 import io.shiftleft.fuzzyc2cpg.ast.walking.ASTNodeVisitor;
+import io.shiftleft.fuzzyc2cpg.outputmodules.OutputModule;
 
 public class ParserCallbacks extends ASTNodeVisitor {
+
+  private final OutputModule outputModule;
+
+  public ParserCallbacks(OutputModule outputModule) {
+    this.outputModule = outputModule;
+  }
 
   /**
    * Callback triggered for each function definition
    * */
 
   public void visit(FunctionDefBase ast) {
-    (new FunctionDefHandler(structureCpg)).handle(ast);
+    (new FunctionDefHandler(structureCpg, outputModule)).handle(ast);
   }
 
   /**

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/ast/walking/AstWalker.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/ast/walking/AstWalker.java
@@ -4,6 +4,8 @@ import io.shiftleft.fuzzyc2cpg.ParserCallbacks;
 import io.shiftleft.fuzzyc2cpg.StructureCpg;
 import io.shiftleft.fuzzyc2cpg.ast.AstNode;
 import io.shiftleft.fuzzyc2cpg.ast.AstNodeBuilder;
+import io.shiftleft.fuzzyc2cpg.outputmodules.OutputModule;
+import io.shiftleft.fuzzyc2cpg.outputmodules.ProtoOutputModule;
 import java.util.Observable;
 import java.util.Observer;
 import java.util.Stack;
@@ -14,7 +16,11 @@ public class AstWalker implements Observer {
   protected ASTNodeVisitor callbacks;
 
   public AstWalker() {
-    callbacks = new ParserCallbacks();
+    callbacks = new ParserCallbacks(new ProtoOutputModule());
+  }
+
+  public void setOutputModule(OutputModule module) {
+    callbacks = new ParserCallbacks(module);
   }
 
   public void startOfUnit(ParserRuleContext ctx, String filename) {

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/outputmodules/InMemoryGraphOutputModule.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/outputmodules/InMemoryGraphOutputModule.java
@@ -1,0 +1,36 @@
+package io.shiftleft.fuzzyc2cpg.outputmodules;
+
+import io.shiftleft.cpgloading.tinkergraph.ProtoToCpg;
+import io.shiftleft.proto.cpg.Cpg.CpgStruct.Builder;
+import io.shiftleft.cpgloading.ProtoCpgLoader;
+import io.shiftleft.queryprimitives.steps.starters.Cpg;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Output module that writes CPG into in memory graph database
+ * */
+public class InMemoryGraphOutputModule implements OutputModule {
+
+  Cpg cpg;
+
+  @Override
+  public void output(Builder cpgBuilder, String outputFilename) {
+    ProtoToCpg protoToCpg = new ProtoToCpg();
+    ProtoCpgLoader protoCpgLoader = new ProtoCpgLoader(protoToCpg);
+
+    byte[] bytes = cpgBuilder.build().toByteArray();
+    InputStream inputStream = new ByteArrayInputStream(bytes);
+    try {
+      cpg = protoCpgLoader.loadFromInputStream(inputStream);
+    } catch (IOException e) {
+      System.err.println("Error loading CPG from byte array input stream");
+    }
+  }
+
+  public Cpg getCpg() {
+    return cpg;
+  }
+
+}

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/outputmodules/OutputModule.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/outputmodules/OutputModule.java
@@ -1,0 +1,9 @@
+package io.shiftleft.fuzzyc2cpg.outputmodules;
+
+import io.shiftleft.proto.cpg.Cpg.CpgStruct.Builder;
+
+public interface OutputModule {
+
+  void output(Builder cpgBuilder, String outputFilename);
+
+}

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/outputmodules/ProtoOutputModule.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/outputmodules/ProtoOutputModule.java
@@ -1,12 +1,11 @@
-package io.shiftleft.fuzzyc2cpg;
+package io.shiftleft.fuzzyc2cpg.outputmodules;
 
 import io.shiftleft.proto.cpg.Cpg.CpgStruct;
 import io.shiftleft.proto.cpg.Cpg.CpgStruct.Builder;
 import java.io.FileOutputStream;
 import java.io.IOException;
 
-public class ProtoOutputModule {
-
+public class ProtoOutputModule implements OutputModule {
 
   public void output(Builder cpgBuilder, String outputFilename) {
     CpgStruct cpgStruct = cpgBuilder.build();

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/parser/CompoundItemAssembler.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/parser/CompoundItemAssembler.java
@@ -4,6 +4,7 @@ import io.shiftleft.fuzzyc2cpg.ast.AstNode;
 import io.shiftleft.fuzzyc2cpg.ast.AstNodeBuilder;
 import io.shiftleft.fuzzyc2cpg.ast.logical.statements.CompoundStatement;
 import io.shiftleft.fuzzyc2cpg.ast.walking.AstWalker;
+import io.shiftleft.fuzzyc2cpg.outputmodules.OutputModule;
 import java.util.Stack;
 import org.antlr.v4.runtime.ParserRuleContext;
 

--- a/src/test/resources/testcode/testtest/test.c
+++ b/src/test/resources/testcode/testtest/test.c
@@ -1,0 +1,4 @@
+
+int foo () {
+  return 1;
+}

--- a/src/test/scala/io/shiftleft/fuzzyc2cpg/CpgTestFixture.scala
+++ b/src/test/scala/io/shiftleft/fuzzyc2cpg/CpgTestFixture.scala
@@ -1,0 +1,16 @@
+package io.shiftleft.fuzzyc2cpg
+
+import io.shiftleft.fuzzyc2cpg.outputmodules.InMemoryGraphOutputModule
+import io.shiftleft.queryprimitives.steps.starters.Cpg
+
+case class CpgTestFixture(projectName: String) {
+
+  val cpg: Cpg = {
+    val dirName = String.format("src/main/resources/testcode/%s", projectName)
+    val inmemoryOutputModule = new InMemoryGraphOutputModule()
+    val fuzzyc2Cpg = new Fuzzyc2Cpg(inmemoryOutputModule)
+    fuzzyc2Cpg.runAndOutput(List(dirName).toArray)
+    inmemoryOutputModule.getCpg
+  }
+
+}

--- a/src/test/scala/io/shiftleft/fuzzyc2cpg/TestTest.scala
+++ b/src/test/scala/io/shiftleft/fuzzyc2cpg/TestTest.scala
@@ -1,0 +1,14 @@
+package io.shiftleft.fuzzyc2cpg
+
+import org.scalatest.{Matchers, WordSpec}
+
+class TestTest extends WordSpec with Matchers {
+  val fixture = CpgTestFixture("testtest")
+
+  "Tests" should {
+    "load graphs" in {
+      fixture.cpg.scalaGraph.V.l.size should be  > 0
+    }
+  }
+
+}


### PR DESCRIPTION
It turns out the code that creates in memory graphs for testing in java2cpg operates on an internal data structure called `CodePropertyGraph`, and so, I could not make use of that code. Instead, I wrote the CPG proto into a bytearray and used the ProtoCpgLoader from `codepropertygraph` to construct the graph from the byte array.
