### PR TITLE
Fix bug in CFG of switch statement.

### DIFF
--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/cfg/AstToCfgConverter.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/cfg/AstToCfgConverter.scala
@@ -409,12 +409,14 @@ class AstToCfgConverter[NodeType](entryNode: NodeType,
     switchStatement.getStatement.accept(this)
     val switchFringe = fringe
 
-    val hasDefaultCase =
-      caseStack.getTopElements.exists { case (caseNode, isDefault) =>
-        fringe = conditionFringe
-        extendCfg(caseNode)
-        isDefault
-      }
+    caseStack.getTopElements.foreach { case (caseNode, isDefault) =>
+      fringe = conditionFringe
+      extendCfg(caseNode)
+    }
+
+    val hasDefaultCase = caseStack.getTopElements.exists { case (caseNode, isDefault) =>
+      isDefault
+    }
 
     fringe = switchFringe.add(breakStack.getTopElements, AlwaysEdge)
 

--- a/src/test/scala/io/shiftleft/fuzzyc2cpg/cfg/AstToCfgTests.scala
+++ b/src/test/scala/io/shiftleft/fuzzyc2cpg/cfg/AstToCfgTests.scala
@@ -379,6 +379,15 @@ class AstToCfgTests extends WordSpec with Matchers {
         succOf("x") shouldBe expected(("y", CaseEdge))
         succOf("y") shouldBe expected(("EXIT", AlwaysEdge))
       }
+
+    "be correct for case and default combined" in
+      new Fixture("switch (x) { case 1: y; break; default: z;}") {
+        succOf("ENTRY") shouldBe expected(("x", AlwaysEdge))
+        succOf("x") shouldBe expected(("y", CaseEdge), ("z", CaseEdge))
+        succOf("y") shouldBe expected(("break;", AlwaysEdge))
+        succOf("break;") shouldBe expected(("EXIT", AlwaysEdge))
+        succOf("z") shouldBe expected(("EXIT", AlwaysEdge))
+      }
   }
 
   "Cfg for if" should {


### PR DESCRIPTION
The CFG was invalid if "case" and "default" labels were used in
combination.