### PR TITLE
Fix handling of const pointers in parameters

### DIFF
--- a/src/main/antlr4/io/shiftleft/fuzzyc2cpg/Common.g4
+++ b/src/main/antlr4/io/shiftleft/fuzzyc2cpg/Common.g4
@@ -134,7 +134,7 @@ water: .;
 identifier : (ALPHA_NUMERIC ('::' ALPHA_NUMERIC)*) | access_specifier;
 number: HEX_LITERAL | DECIMAL_LITERAL | OCTAL_LITERAL;
 
-ptrs: (ptr_operator 'restrict'?)+;
+ptrs: (CV_QUALIFIER? ptr_operator 'restrict'?)+;
 func_ptrs: ptrs;
 
 

--- a/src/test/java/io/shiftleft/fuzzyc2cpg/antlrparsers/moduleparser/FunctionParameterTests.java
+++ b/src/test/java/io/shiftleft/fuzzyc2cpg/antlrparsers/moduleparser/FunctionParameterTests.java
@@ -60,4 +60,15 @@ public class FunctionParameterTests extends FunctionDefinitionTests
 		String output = parser.function_def().toStringTree(parser);
 		assertTrue(output.startsWith("(function_def"));
 	}
+
+	@Test
+	public void testConstConstPtr()
+	{
+		String input = "static void black_box(const example_s * const * alias_to_alias) {}";
+
+		ModuleParser parser = createParser(input);
+		String output = parser.function_def().toStringTree(parser);
+		assertTrue(output.startsWith("(function_def"));
+	}
+
 }


### PR DESCRIPTION
We previously did not identify the following method signature:
```
static void black_box(const example_s * const * alias_to_alias){}
```
because we did not account for the fact that `const` can occur in the middle of the type. This PR fixes this and adds a corresponding test.