### PR TITLE
use latest release plugin, which only pushes the tag after release

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.5")
 addSbtPlugin("com.simplytyped" % "sbt-antlr4" % "0.8.1")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.8.0")
 addSbtPlugin("com.github.sbt" % "sbt-findbugs" % "2.0.0")
-addSbtPlugin("io.shiftleft" % "sbt-ci-release-early"  % "1.0.12")
+addSbtPlugin("io.shiftleft" % "sbt-ci-release-early"  % "1.0.15")
 
 /* TODO upgrade sbt-git to 1.0.1 once that has been released including: https://github.com/sbt/sbt-git/pull/162
  */


### PR DESCRIPTION
this should avoid that timeout issues (which happen during sonatype release occasionally) lead to incorrectly tagged repositories