### PR TITLE
Minor cleanup of FuzzyC2CPG classes

### DIFF
--- a/src/main/java/io/shiftleft/fuzzyc2cpg/Fuzzyc2Cpg.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/Fuzzyc2Cpg.java
@@ -3,6 +3,8 @@ package io.shiftleft.fuzzyc2cpg;
 import io.shiftleft.fuzzyc2cpg.filewalker.OrderedWalker;
 import io.shiftleft.fuzzyc2cpg.filewalker.SourceFileWalker;
 import io.shiftleft.fuzzyc2cpg.output.CpgOutputModuleFactory;
+import io.shiftleft.fuzzyc2cpg.output.protobuf.OutputModuleFactory;
+
 import java.io.File;
 import java.io.IOException;
 
@@ -11,6 +13,23 @@ public class Fuzzyc2Cpg {
   private FileWalkerCallbacks parser;
   private SourceFileWalker sourceFileWalker = new OrderedWalker();
 
+  /**
+   * Construct a FuzzyC2CPG instance that employs the default
+   * protobuf output module.
+   *
+   * @param outputPath the filename for the output CPG
+   * */
+  public Fuzzyc2Cpg(String outputPath) throws IOException {
+    this(new OutputModuleFactory(outputPath,
+            true, false));
+  }
+
+  /**
+   * Construct a FuzzyC2CPG instance that employs the
+   * output module created by the given output module factory.
+   *
+   * @param outputModuleFactory the factory
+   * */
   public Fuzzyc2Cpg(CpgOutputModuleFactory<?> outputModuleFactory) {
     setupParser(outputModuleFactory);
   }

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
@@ -1,6 +1,5 @@
 package io.shiftleft.fuzzyc2cpg
 
-import io.shiftleft.fuzzyc2cpg.output.protobuf.OutputModuleFactory
 import org.slf4j.LoggerFactory
 
 object FuzzyC2Cpg extends App {
@@ -9,11 +8,9 @@ object FuzzyC2Cpg extends App {
 
   private val logger = LoggerFactory.getLogger(getClass)
 
-  parseConfig.map{ config =>
+  parseConfig.foreach{ config =>
     try {
-      val fuzzyc2Cpg = new Fuzzyc2Cpg(new OutputModuleFactory(config.outputPath,
-        true, false))
-      fuzzyc2Cpg.runAndOutput(config.inputPaths.toArray)
+      new Fuzzyc2Cpg(config.outputPath).runAndOutput(config.inputPaths.toArray)
     } catch {
       case exception: Exception =>
         logger.error("Failed to generate CPG.", exception)


### PR DESCRIPTION
- added a construct to create a FuzzyC2CPG instance given only an output path
- do not use `map` when return value is not required
- add scaladoc strings