### PR TITLE
Make fuzzyc2cpg silent if there are no failures

### DIFF
--- a/src/main/java/io/shiftleft/fuzzyc2cpg/output/protobuf/ThreadedZipper.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/output/protobuf/ThreadedZipper.java
@@ -83,7 +83,6 @@ class ThreadedZipper extends Thread {
             logger.error("Couldn't list files in " + inputFile);
             return;
           }
-          logger.info("Found " + files.length + " files");
           Arrays.sort(files);
 
           List<ZipEntry> entries = Arrays.stream(files).flatMap(f -> {


### PR DESCRIPTION
There was a confusing message from the ThreadedZipper that showed up, even on successful runs of the language frontend. I just removed it.