### PR TITLE
Do not crash if there is no throw exception.

### DIFF
--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgConverter.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgConverter.scala
@@ -467,7 +467,10 @@ class AstToCpgConverter[NodeBuilderType, NodeType](containingFileName: String,
     addAstChild(cpgThrow)
 
     pushContext(cpgThrow, 1)
-    astThrow.getThrowExpression.accept(this)
+    val throwExpression = astThrow.getThrowExpression
+    if (throwExpression != null) {
+      throwExpression.accept(this)
+    }
     popContext()
   }
 

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/cfg/AstToCfgConverter.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/cfg/AstToCfgConverter.scala
@@ -449,7 +449,10 @@ class AstToCfgConverter[NodeType](entryNode: NodeType, exitNode: NodeType, adapt
   }
 
   override def visit(throwStatement: ThrowStatement): Unit = {
-    throwStatement.getThrowExpression.accept(this)
+    val throwExpression = throwStatement.getThrowExpression
+    if (throwExpression != null) {
+      throwExpression.accept(this)
+    }
     // TODO at the moment we do not handle exception handling
     // and thus simply ignore the influence of 'throw' on the
     // cfg.


### PR DESCRIPTION
For c++ code just rethrowing an exception in a catch block like this:
catch(...) {
  ...
  throw;
}

There is no throw exception because the exception thrown is implicitly
specified.