### PR TITLE
Change sizeof grammar to whenever possible handle...

### DIFF
--- a/src/main/antlr4/io/shiftleft/fuzzyc2cpg/Common.g4
+++ b/src/main/antlr4/io/shiftleft/fuzzyc2cpg/Common.g4
@@ -193,8 +193,9 @@ new_expression: '::'? NEW type_name '[' conditional_expression? ']'
 
 unary_op_and_cast_expr: unary_operator cast_expression;
 
-sizeof_expression: sizeof '(' sizeof_operand ')'
-                 | sizeof sizeof_operand2;
+sizeof_expression: sizeof sizeof_operand2
+                 | sizeof '(' sizeof_operand2 ')'
+                 | sizeof '(' sizeof_operand ')';
 
 sizeof: 'sizeof';
 


### PR DESCRIPTION
... the sizeof operand as expression.
This leads to CALL and IDENTIFIER representations in the CPG.
We previously represented the operands of sizeof(...) as UNKNOWN.