### PR TITLE
Fix identifier declaration handling.

### DIFF
--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgConverter.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgConverter.scala
@@ -561,24 +561,28 @@ class AstToCpgConverter[NodeBuilderType, NodeType](containingFileName: String,
         .createNode(identifierDecl)
       addAstChild(cpgMember)
     } else {
-      val localName = identifierDecl.getName.getEscapedCodeStr
-      val cpgLocal = adapter
-        .createNodeBuilder(NodeKind.LOCAL)
-        .addProperty(NodeProperty.CODE, localName)
-        .addProperty(NodeProperty.NAME, localName)
-        .addProperty(NodeProperty.TYPE_FULL_NAME, registerType(declTypeName))
-        .createNode(identifierDecl)
+      // We only process file level identifier declarations if they are typedefs.
+      // Everything else is ignored.
+      if (!scope.isEmpty) {
+        val localName = identifierDecl.getName.getEscapedCodeStr
+        val cpgLocal = adapter
+          .createNodeBuilder(NodeKind.LOCAL)
+          .addProperty(NodeProperty.CODE, localName)
+          .addProperty(NodeProperty.NAME, localName)
+          .addProperty(NodeProperty.TYPE_FULL_NAME, registerType(declTypeName))
+          .createNode(identifierDecl)
 
-      val scopeParentNode =
-        scope.addToScope(localName, (cpgLocal, declTypeName))
-      // Here we on purpose do not use addAstChild because the LOCAL nodes
-      // are not really in the AST (they also have no ORDER property).
-      // So do not be confused that the format still demands an AST edge.
-      adapter.addEdge(EdgeKind.AST, cpgLocal, scopeParentNode)
+        val scopeParentNode =
+          scope.addToScope(localName, (cpgLocal, declTypeName))
+        // Here we on purpose do not use addAstChild because the LOCAL nodes
+        // are not really in the AST (they also have no ORDER property).
+        // So do not be confused that the format still demands an AST edge.
+        adapter.addEdge(EdgeKind.AST, cpgLocal, scopeParentNode)
 
-      val assignmentExpression = identifierDecl.getAssignment
-      if (assignmentExpression != null) {
-        assignmentExpression.accept(this)
+        val assignmentExpression = identifierDecl.getAssignment
+        if (assignmentExpression != null) {
+          assignmentExpression.accept(this)
+        }
       }
     }
   }

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/scope/Scope.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/scope/Scope.scala
@@ -9,6 +9,10 @@ package io.shiftleft.fuzzyc2cpg.scope
 class Scope[I, V, S] {
   private var stack = List[ScopeElement[I, V, S]]()
 
+  def isEmpty: Boolean = {
+    stack.isEmpty
+  }
+
   def pushNewScope(scopeNode: S): Unit = {
     stack = ScopeElement[I, V, S](scopeNode) :: stack
   }


### PR DESCRIPTION
For the handling of typedefs, we introduced processing of file level identifier
declarations. This change lets us only handle typedef and not variable
definitions.