### PR TITLE
Switch CFG for nested switch statements.

### DIFF
--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/cfg/AstToCfgConverter.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/cfg/AstToCfgConverter.scala
@@ -417,12 +417,17 @@ class AstToCfgConverter[NodeType](entryNode: NodeType, exitNode: NodeType, adapt
   }
 
   override def visit(switchStatement: SwitchStatement): Unit = {
-    breakStack.pushLayer()
-    caseStack.pushLayer()
-
     switchStatement.getCondition.accept(this)
     val conditionFringe = fringe.setCfgEdgeType(CaseEdge)
     fringe = fringe.empty()
+
+    // We can only push the break and case stacks after we processed the condition
+    // in order to allow for nested switches with no nodes CFG nodes in between
+    // an outer switch case label and the inner switch condition.
+    // This is ok because in C/C++ it is not allowed to have another switch
+    // statement in the condition of a switch statement.
+    breakStack.pushLayer()
+    caseStack.pushLayer()
 
     switchStatement.getStatement.accept(this)
     val switchFringe = fringe

--- a/src/test/scala/io/shiftleft/fuzzyc2cpg/cfg/AstToCfgTests.scala
+++ b/src/test/scala/io/shiftleft/fuzzyc2cpg/cfg/AstToCfgTests.scala
@@ -403,6 +403,14 @@ class AstToCfgTests extends WordSpec with Matchers {
         succOf("break;") shouldBe expected(("EXIT", AlwaysEdge))
         succOf("z") shouldBe expected(("EXIT", AlwaysEdge))
       }
+
+    "be correct for nested switch" in
+      new Fixture("switch (x) { default: switch(y) { default: z; } }") {
+        succOf("ENTRY") shouldBe expected(("x", AlwaysEdge))
+        succOf("x") shouldBe expected(("y", CaseEdge))
+        succOf("y") shouldBe expected(("z", CaseEdge))
+        succOf("z") shouldBe expected(("EXIT", AlwaysEdge))
+      }
   }
 
   "Cfg for if" should {


### PR DESCRIPTION
In case of no CFG element between outer switch case label and inner
switch condition the CFG was messed up.