### PR TITLE
Make debug messages less alerting

### DIFF
--- a/src/main/java/io/shiftleft/fuzzyc2cpg/parser/ModuleFunctionParserInterface.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/parser/ModuleFunctionParserInterface.java
@@ -23,8 +23,8 @@ public class ModuleFunctionParserInterface {
     try {
       driver.parseAndWalkString(text);
     } catch (RuntimeException ex) {
-      System.err.println("Error parsing function "
-          + ctx.function_name().getText() + ". skipping.");
+      System.err.println("Info: "
+          + ctx.function_name().getText() + " was skipped.");
       //ex.printStackTrace();
     }
     CompoundStatement result = driver.getResult();

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/parser/ModuleFunctionParserInterface.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/parser/ModuleFunctionParserInterface.java
@@ -7,8 +7,13 @@ import io.shiftleft.fuzzyc2cpg.parser.functions.AntlrCFunctionParserDriver;
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.misc.Interval;
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ModuleFunctionParserInterface {
+
+  static Logger logger = LoggerFactory.getLogger(ModuleFunctionParserInterface.class);
+
   // Extracts compound statement from input stream
   // as a string and passes that string to the
   // function parser. The resulting 'CompoundStatement'
@@ -23,8 +28,7 @@ public class ModuleFunctionParserInterface {
     try {
       driver.parseAndWalkString(text);
     } catch (RuntimeException ex) {
-      System.err.println("Info: "
-          + ctx.function_name().getText() + " was skipped.");
+      logger.info(ctx.function_name().getText() + " was skipped.");
       //ex.printStackTrace();
     }
     CompoundStatement result = driver.getResult();

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/cfg/AstToCfgConverter.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/cfg/AstToCfgConverter.scala
@@ -109,7 +109,7 @@ class AstToCfgConverter[NodeType](entryNode: NodeType, exitNode: NodeType, adapt
           case Some(labeledNode) =>
             adapter.newCfgEdge(labeledNode, goto, AlwaysEdge)
           case None =>
-            logger.warn("Unable to wire goto statement. Missing label {}.", label)
+            logger.info("Unable to wire goto statement. Missing label {}.", label)
         }
     }
   }


### PR DESCRIPTION
With a fuzzy parser, it can happen that a function cannot be parsed or that a goto statement cannot be wired. That's good to know, but we shouldn't use the words "ERROR" or "WARNING" in this case, as it gives a false impression of severity.