### PR TITLE
Get rid of type parameter for `CpgOutputModuleFactory`

### DIFF
--- a/src/main/java/io/shiftleft/fuzzyc2cpg/output/CpgOutputModuleFactory.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/output/CpgOutputModuleFactory.java
@@ -4,9 +4,8 @@ import java.io.IOException;
 
 /**
  * Output module factory.
- * @param <T> The internal type of the graph
  */
-public interface CpgOutputModuleFactory<T> {
+public interface CpgOutputModuleFactory {
 
   /**
    * A CpgOutputModule associated with the given factory.
@@ -14,13 +13,6 @@ public interface CpgOutputModuleFactory<T> {
    * @return a singleton output module
    */
   CpgOutputModule create() throws IOException;
-
-  /**
-   * An internal representation of the graph.
-   *
-   * @return the internally constructed graph
-   */
-  T getInternalGraph();
 
   /**
    * A finalization method that potentially combines all CPGs added to any of the

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/output/inmemory/OutputModuleFactory.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/output/inmemory/OutputModuleFactory.java
@@ -4,7 +4,7 @@ import io.shiftleft.codepropertygraph.Cpg;
 import io.shiftleft.fuzzyc2cpg.output.CpgOutputModule;
 import io.shiftleft.fuzzyc2cpg.output.CpgOutputModuleFactory;
 
-public class OutputModuleFactory implements CpgOutputModuleFactory<Cpg> {
+public class OutputModuleFactory implements CpgOutputModuleFactory {
 
   private OutputModule outputModule;
 
@@ -18,7 +18,11 @@ public class OutputModuleFactory implements CpgOutputModuleFactory<Cpg> {
     return outputModule;
   }
 
-  @Override
+  /**
+   * An internal representation of the graph.
+   *
+   * @return the internally constructed graph
+   */
   public Cpg getInternalGraph() {
     return outputModule.getInternalGraph();
   }

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/output/protobuf/OutputModuleFactory.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/output/protobuf/OutputModuleFactory.java
@@ -2,18 +2,16 @@ package io.shiftleft.fuzzyc2cpg.output.protobuf;
 
 import io.shiftleft.fuzzyc2cpg.output.CpgOutputModule;
 import io.shiftleft.fuzzyc2cpg.output.CpgOutputModuleFactory;
-import io.shiftleft.proto.cpg.Cpg.CpgStruct;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.apache.commons.io.FileUtils;
 
-public class OutputModuleFactory implements CpgOutputModuleFactory<List<CpgStruct>> {
+public class OutputModuleFactory implements CpgOutputModuleFactory {
 
   private final List<OutputModule> outputModules = new ArrayList<>();
   private final boolean writeToDisk;
@@ -37,21 +35,6 @@ public class OutputModuleFactory implements CpgOutputModuleFactory<List<CpgStruc
       outputModules.add(outputModule);
     }
     return outputModule;
-  }
-
-  @Override
-  public List<CpgStruct> getInternalGraph() {
-    if (!keepInternalGraph) {
-      throw new RuntimeException("Requested internal graph but `keepInternalGraph` is false");
-    }
-    List<CpgStruct> result;
-
-    synchronized (this) {
-      result = outputModules.stream()
-          .map(OutputModule::getProtoCpg)
-          .collect(Collectors.toList());
-    }
-    return result;
   }
 
   /**

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/parser/AntlrParserDriver.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/parser/AntlrParserDriver.java
@@ -40,7 +40,7 @@ abstract public class AntlrParserDriver {
   private CommonParserContext context = null;
 
   private List<AntlrParserDriverObserver> observers = new ArrayList<>();
-  private CpgOutputModuleFactory<?> outputModuleFactory;
+  private CpgOutputModuleFactory outputModuleFactory;
   private Cpg.CpgStruct.Builder cpg;
   private Cpg.CpgStruct.Node namespaceBlock;
   private Cpg.CpgStruct.Node fileNode;
@@ -49,7 +49,7 @@ abstract public class AntlrParserDriver {
     super();
   }
 
-  public void setOutputModuleFactory(CpgOutputModuleFactory<?> factory) {
+  public void setOutputModuleFactory(CpgOutputModuleFactory factory) {
     this.outputModuleFactory = factory;
   }
 

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/AstVisitor.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/AstVisitor.scala
@@ -15,7 +15,7 @@ import io.shiftleft.proto.cpg.Cpg.CpgStruct
 import io.shiftleft.proto.cpg.Cpg.CpgStruct.Node
 import org.antlr.v4.runtime.ParserRuleContext
 
-class AstVisitor(outputModuleFactory: CpgOutputModuleFactory[_], structureCpg: CpgStruct.Builder, astParentNode: Node)
+class AstVisitor(outputModuleFactory: CpgOutputModuleFactory, structureCpg: CpgStruct.Builder, astParentNode: Node)
     extends ASTNodeVisitor
     with AntlrParserDriverObserver {
   private var fileNameOption = Option.empty[String]

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
@@ -14,11 +14,12 @@ import io.shiftleft.fuzzyc2cpg.Utils._
 import io.shiftleft.fuzzyc2cpg.output.CpgOutputModuleFactory
 import io.shiftleft.fuzzyc2cpg.parser.modules.AntlrCModuleParserDriver
 
-class FuzzyC2Cpg(outputModuleFactory : CpgOutputModuleFactory) {
+class FuzzyC2Cpg(outputModuleFactory: CpgOutputModuleFactory) {
 
-  def this(outputPath : String) = {
-    this(new OutputModuleFactory(outputPath, true, false)
-      .asInstanceOf[CpgOutputModuleFactory])
+  def this(outputPath: String) = {
+    this(
+      new OutputModuleFactory(outputPath, true, false)
+        .asInstanceOf[CpgOutputModuleFactory])
   }
 
   def runAndOutput(fileAndDirNames: Array[String]) = {
@@ -33,17 +34,17 @@ class FuzzyC2Cpg(outputModuleFactory : CpgOutputModuleFactory) {
     outputModuleFactory.persist()
   }
 
-  private def createStructuralCpg(filenames: List[String], cpgOutputModuleFactory: CpgOutputModuleFactory):
-    List[(String, NodesForFile)] = {
+  private def createStructuralCpg(filenames: List[String],
+                                  cpgOutputModuleFactory: CpgOutputModuleFactory): List[(String, NodesForFile)] = {
 
-    def addMetaDataNode(cpg : CpgStruct.Builder): Unit = {
+    def addMetaDataNode(cpg: CpgStruct.Builder): Unit = {
       val metaNode = newNode(NodeType.META_DATA)
         .addStringProperty(NodePropertyName.LANGUAGE, Languages.C)
         .build
       cpg.addNode(metaNode)
     }
 
-    def addAnyTypeAndNamespaceBlock(cpg : CpgStruct.Builder): Unit = {
+    def addAnyTypeAndNamespaceBlock(cpg: CpgStruct.Builder): Unit = {
       val globalNamespaceBlockNotInFileNode = createNamespaceBlockNode(None)
       cpg.addNode(globalNamespaceBlockNotInFileNode)
     }
@@ -54,8 +55,8 @@ class FuzzyC2Cpg(outputModuleFactory : CpgOutputModuleFactory) {
         .build()
     }
 
-    def createNodesForFiles(cpg: CpgStruct.Builder) : List[(String, NodesForFile)] =
-      filenames.map{filename =>
+    def createNodesForFiles(cpg: CpgStruct.Builder): List[(String, NodesForFile)] =
+      filenames.map { filename =>
         val pathToFile = new java.io.File(filename).toPath
         val fileNode = createFileNode(pathToFile)
         val namespaceBlock = createNamespaceBlockNode(Some(pathToFile))
@@ -63,7 +64,7 @@ class FuzzyC2Cpg(outputModuleFactory : CpgOutputModuleFactory) {
         cpg.addNode(namespaceBlock)
         cpg.addEdge(newEdge(EdgeType.AST, namespaceBlock, fileNode))
         filename -> new NodesForFile(fileNode, namespaceBlock)
-    }
+      }
 
     val cpg = CpgStruct.newBuilder()
     addMetaDataNode(cpg)
@@ -75,7 +76,7 @@ class FuzzyC2Cpg(outputModuleFactory : CpgOutputModuleFactory) {
     filenameToNodes
   }
 
-  case class NodesForFile(fileNode : CpgStruct.Node, namespaceBlockNode: CpgStruct.Node) {}
+  case class NodesForFile(fileNode: CpgStruct.Node, namespaceBlockNode: CpgStruct.Node) {}
 
   private def createNamespaceBlockNode(filePath: Option[Path]): Node = {
     newNode(NodeType.NAMESPACE_BLOCK)
@@ -118,7 +119,7 @@ object FuzzyC2Cpg extends App {
 
   private val logger = LoggerFactory.getLogger(getClass)
 
-  parseConfig.foreach{ config =>
+  parseConfig.foreach { config =>
     try {
       new FuzzyC2Cpg(config.outputPath).runAndOutput(config.inputPaths.toArray)
     } catch {

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
@@ -14,11 +14,11 @@ import io.shiftleft.fuzzyc2cpg.Utils._
 import io.shiftleft.fuzzyc2cpg.output.CpgOutputModuleFactory
 import io.shiftleft.fuzzyc2cpg.parser.modules.AntlrCModuleParserDriver
 
-class FuzzyC2Cpg[T](outputModuleFactory : CpgOutputModuleFactory[T]) {
+class FuzzyC2Cpg(outputModuleFactory : CpgOutputModuleFactory) {
 
   def this(outputPath : String) = {
     this(new OutputModuleFactory(outputPath, true, false)
-      .asInstanceOf[CpgOutputModuleFactory[T]])
+      .asInstanceOf[CpgOutputModuleFactory])
   }
 
   def runAndOutput(fileAndDirNames: Array[String]) = {
@@ -33,7 +33,7 @@ class FuzzyC2Cpg[T](outputModuleFactory : CpgOutputModuleFactory[T]) {
     outputModuleFactory.persist()
   }
 
-  private def createStructuralCpg(filenames: List[String], cpgOutputModuleFactory: CpgOutputModuleFactory[T]):
+  private def createStructuralCpg(filenames: List[String], cpgOutputModuleFactory: CpgOutputModuleFactory):
     List[(String, NodesForFile)] = {
 
     def addMetaDataNode(cpg : CpgStruct.Builder): Unit = {

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/SourceFiles.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/SourceFiles.scala
@@ -8,9 +8,9 @@ object SourceFiles {
     * For a given array of input paths, determine all C/C++
     * source files by inspecting filename extensions.
     * */
-  def determine(inputPaths : List[String])  : List[String]= {
+  def determine(inputPaths: List[String]): List[String] = {
 
-    def hasSourceFileExtension(file : File) : Boolean = {
+    def hasSourceFileExtension(file: File): Boolean = {
       val ext = file.extension
       ext.contains(".c") || ext.contains(".cpp") || ext.contains(".h") || ext.contains(".hpp")
     }
@@ -18,8 +18,9 @@ object SourceFiles {
     val (dirs, files) = inputPaths.partition(File(_).isDirectory)
 
     val matchingFiles = files.filter(f => hasSourceFileExtension(File(f)))
-    val matchingFilesFromDirs = dirs.flatMap(dir => File(dir).listRecursively.filter(hasSourceFileExtension))
-        .map(File(".").path.relativize(_).toString)
+    val matchingFilesFromDirs = dirs
+      .flatMap(dir => File(dir).listRecursively.filter(hasSourceFileExtension))
+      .map(File(".").path.relativize(_).toString)
 
     matchingFiles ++ matchingFilesFromDirs
   }

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/ProtoCpgAdapter.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/ProtoCpgAdapter.scala
@@ -60,8 +60,8 @@ class ProtoCpgAdapter(targetCpg: CpgStruct.Builder) extends CpgAdapter[Node.Buil
       case NodeProperty.AST_PARENT_TYPE  => NodePropertyName.AST_PARENT_TYPE
       case NodeProperty.AST_PARENT_FULL_NAME =>
         NodePropertyName.AST_PARENT_FULL_NAME
-      case NodeProperty.LINE_NUMBER   => NodePropertyName.LINE_NUMBER
-      case NodeProperty.COLUMN_NUMBER => NodePropertyName.COLUMN_NUMBER
+      case NodeProperty.LINE_NUMBER          => NodePropertyName.LINE_NUMBER
+      case NodeProperty.COLUMN_NUMBER        => NodePropertyName.COLUMN_NUMBER
       case NodeProperty.ALIAS_TYPE_FULL_NAME => NodePropertyName.ALIAS_TYPE_FULL_NAME
     }
   }


### PR DESCRIPTION
I am getting rid of some unnecessary complexity before we hand this module over to someone else. In this PR, I am getting rid of the type parameter for `CpgOutputModuleFactory`, which isn't required anymore.