### PR TITLE
Update to newest CPG version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "fuzzyc2cpg"
 organization := "io.shiftleft"
 scalaVersion := "2.12.7"
 
-val cpgVersion = "0.9.263"
+val cpgVersion = "0.9.280"
 
 libraryDependencies ++= Seq(
   "com.github.scopt"   %% "scopt"          % "3.7.0",
@@ -20,6 +20,13 @@ libraryDependencies ++= Seq(
 // uncomment if you want to use a cpg version that has *just* been released
 // (it takes a few hours until it syncs to maven central)
 resolvers += "Sonatype OSS" at "https://oss.sonatype.org/content/repositories/public"
+ThisBuild / resolvers ++= Seq(
+  Resolver.mavenLocal,
+  "Artifactory release local" at "https://shiftleft.jfrog.io/shiftleft/libs-release-local",
+  "Apache public" at "https://repository.apache.org/content/groups/public/",
+  "Sonatype OSS" at "https://oss.sonatype.org/content/repositories/public",
+  "Bedatadriven for SOOT dependencies" at "https://nexus.bedatadriven.com/content/groups/public"
+)
 
 scalacOptions ++= Seq("-deprecation", "-feature")
 compile / javacOptions ++= Seq("-Xlint:all", "-Xlint:-cast", "-g")

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/output/inmemory/OutputModule.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/output/inmemory/OutputModule.java
@@ -3,28 +3,21 @@ package io.shiftleft.fuzzyc2cpg.output.inmemory;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.HashMap;
 import java.util.LinkedList;
-import java.util.Map;
+import java.util.List;
 import java.util.Optional;
 
 import io.shiftleft.codepropertygraph.Cpg;
 import io.shiftleft.codepropertygraph.cpgloading.ProtoCpgLoader;
 import io.shiftleft.fuzzyc2cpg.output.CpgOutputModule;
 import io.shiftleft.proto.cpg.Cpg.CpgStruct;
-import org.apache.tinkerpop.gremlin.structure.Vertex;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class OutputModule implements CpgOutputModule {
-  private static Logger logger = LoggerFactory.getLogger(OutputModule.class);
 
-  private Map<Long, Vertex> nodeIdToVertex;
   private LinkedList<CpgStruct.Builder> cpgBuilders;
   private Cpg cpg;
 
   protected OutputModule() {
-    this.nodeIdToVertex = new HashMap<>();
     this.cpgBuilders = new LinkedList<>();
   }
 
@@ -39,7 +32,6 @@ public class OutputModule implements CpgOutputModule {
 
   @Override
   public void persistCpg(CpgStruct.Builder cpg) {
-
     synchronized (cpgBuilders) {
       cpgBuilders.add(cpg);
     }
@@ -56,14 +48,10 @@ public class OutputModule implements CpgOutputModule {
       mergedBuilder.mergeFrom(builder.build());
     });
 
-    byte[] bytes = mergedBuilder.build().toByteArray();
-    InputStream inputStream = new ByteArrayInputStream(bytes);
-    try {
-      cpg = ProtoCpgLoader.loadFromInputStream(inputStream, Optional.empty());
-    } catch (IOException e) {
-      System.err.println("Error loading CPG from byte array input stream");
-      cpg = null;
-    }
+    List<CpgStruct> list = new LinkedList<>();
+    list.add(mergedBuilder.build());
+    cpg = ProtoCpgLoader.loadFromListOfProtos(list, Optional.empty());
+
   }
 
 }


### PR DESCRIPTION
- Allow fetching of dependencies from local maven cache
- Simplify inmemory output module to use new API
- Bump `codepropertygraph` version