### PR TITLE
UNKNOWN -> CONTROL_STRUCTURE

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "fuzzyc2cpg"
 organization := "io.shiftleft"
 scalaVersion := "2.12.7"
 
-val cpgVersion = "0.9.280+2-cdcfdaa7"
+val cpgVersion = "0.9.281"
 
 libraryDependencies ++= Seq(
   "com.github.scopt"   %% "scopt"          % "3.7.0",

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "fuzzyc2cpg"
 organization := "io.shiftleft"
 scalaVersion := "2.12.7"
 
-val cpgVersion = "0.9.280"
+val cpgVersion = "0.9.280+2-cdcfdaa7"
 
 libraryDependencies ++= Seq(
   "com.github.scopt"   %% "scopt"          % "3.7.0",

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgConverter.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgConverter.scala
@@ -396,13 +396,15 @@ class AstToCpgConverter[NodeBuilderType, NodeType](containingFileName: String,
     condition.getExpression.accept(this)
   }
 
-  private def conditionChild(node : AstNode) : Option[Condition] = {
+  private def conditionChild(node: AstNode): Option[Condition] = {
     if (node.getChildCount == 0) {
       None
     }
-    node.getChildIterator.asScala.filter(_.isInstanceOf[Condition])
+    node.getChildIterator.asScala
+      .filter(_.isInstanceOf[Condition])
       .map(_.asInstanceOf[Condition])
-      .toList.headOption
+      .toList
+      .headOption
   }
 
   override def visit(astConditionalExpr: ConditionalExpression): Unit = {
@@ -739,7 +741,7 @@ class AstToCpgConverter[NodeBuilderType, NodeType](containingFileName: String,
       .createNode(astNode)
   }
 
-  private def newConditionNode(astNode: AstNode, parserTypeNameArg : String = ""): NodeType = {
+  private def newConditionNode(astNode: AstNode, parserTypeNameArg: String = ""): NodeType = {
     val parserTypeName = if (parserTypeNameArg.isEmpty) { astNode.getClass.getSimpleName } else { parserTypeNameArg }
     adapter
       .createNodeBuilder(NodeKind.CONDITION)

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgConverter.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgConverter.scala
@@ -8,7 +8,7 @@ import io.shiftleft.fuzzyc2cpg.ast.expressions._
 import io.shiftleft.fuzzyc2cpg.ast.functionDef.FunctionDefBase
 import io.shiftleft.fuzzyc2cpg.ast.langc.expressions.{CallExpression, SizeofExpression}
 import io.shiftleft.fuzzyc2cpg.ast.langc.functiondef.Parameter
-import io.shiftleft.fuzzyc2cpg.ast.langc.statements.blockstarters.{ElseStatement, IfStatement}
+import io.shiftleft.fuzzyc2cpg.ast.langc.statements.blockstarters.IfStatement
 import io.shiftleft.fuzzyc2cpg.ast.logical.statements.{BlockStarter, CompoundStatement, Label, Statement}
 import io.shiftleft.fuzzyc2cpg.ast.statements.blockstarters.CatchList
 import io.shiftleft.fuzzyc2cpg.ast.statements.jump._

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgConverter.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgConverter.scala
@@ -398,7 +398,7 @@ class AstToCpgConverter[NodeBuilderType, NodeType](containingFileName: String,
 
   override def visit(astConditionalExpr: ConditionalExpression): Unit = {
     val cpgConditionalExpr =
-      createCallNode(astConditionalExpr, "<operator>.conditionalExpression")
+      newConditionNode(astConditionalExpr);
 
     addAstChild(cpgConditionalExpr)
 
@@ -411,11 +411,11 @@ class AstToCpgConverter[NodeBuilderType, NodeType](containingFileName: String,
     // We only end up here for expressions chained by ','.
     // Those expressions are than the children of the expression
     // given as parameter.
-    val classOfExression = expression.getClass
-    if (classOfExression != classOf[Expression]) {
+    val classOfExpression = expression.getClass
+    if (classOfExpression != classOf[Expression]) {
       throw new RuntimeException(
         s"Only direct instances of Expressions expected " +
-          s"but ${classOfExression.getSimpleName} found")
+          s"but ${classOfExpression.getSimpleName} found")
     }
 
     val cpgBlock = adapter
@@ -440,7 +440,7 @@ class AstToCpgConverter[NodeBuilderType, NodeType](containingFileName: String,
   }
 
   override def visit(astBlockStarter: BlockStarter): Unit = {
-    val cpgBlockStarter = newUnknownNode(astBlockStarter)
+    val cpgBlockStarter = newConditionNode(astBlockStarter)
 
     addAstChild(cpgBlockStarter)
 
@@ -474,7 +474,7 @@ class AstToCpgConverter[NodeBuilderType, NodeType](containingFileName: String,
   }
 
   override def visit(astIfStmt: IfStatement): Unit = {
-    val cpgIfStmt = newUnknownNode(astIfStmt)
+    val cpgIfStmt = newConditionNode(astIfStmt)
 
     addAstChild(cpgIfStmt)
 
@@ -718,6 +718,14 @@ class AstToCpgConverter[NodeBuilderType, NodeType](containingFileName: String,
   private def newUnknownNode(astNode: AstNode): NodeType = {
     adapter
       .createNodeBuilder(NodeKind.UNKNOWN)
+      .addProperty(NodeProperty.PARSER_TYPE_NAME, astNode.getClass.getSimpleName)
+      .addCommons(astNode, context)
+      .createNode(astNode)
+  }
+
+  private def newConditionNode(astNode: AstNode): NodeType = {
+    adapter
+      .createNodeBuilder(NodeKind.CONDITION)
       .addProperty(NodeProperty.PARSER_TYPE_NAME, astNode.getClass.getSimpleName)
       .addCommons(astNode, context)
       .createNode(astNode)

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/CpgAdapter.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/CpgAdapter.scala
@@ -14,7 +14,7 @@ object NodeProperty extends Enumeration {
 object NodeKind extends Enumeration {
   type NodeKind = Value
   val METHOD, METHOD_RETURN, METHOD_PARAMETER_IN, METHOD_INST, CALL, LITERAL, IDENTIFIER, BLOCK, RETURN, LOCAL, TYPE,
-  TYPE_DECL, MEMBER, NAMESPACE_BLOCK, UNKNOWN = Value
+  TYPE_DECL, MEMBER, NAMESPACE_BLOCK, CONDITION, UNKNOWN = Value
 }
 
 object EdgeKind extends Enumeration {

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/CpgAdapter.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/CpgAdapter.scala
@@ -14,7 +14,7 @@ object NodeProperty extends Enumeration {
 object NodeKind extends Enumeration {
   type NodeKind = Value
   val METHOD, METHOD_RETURN, METHOD_PARAMETER_IN, METHOD_INST, CALL, LITERAL, IDENTIFIER, BLOCK, RETURN, LOCAL, TYPE,
-  TYPE_DECL, MEMBER, NAMESPACE_BLOCK, CONDITION, UNKNOWN = Value
+  TYPE_DECL, MEMBER, NAMESPACE_BLOCK, CONTROL_STRUCTURE, UNKNOWN = Value
 }
 
 object EdgeKind extends Enumeration {

--- a/src/test/scala/io/shiftleft/fuzzyc2cpg/ProgramStructureTests.scala
+++ b/src/test/scala/io/shiftleft/fuzzyc2cpg/ProgramStructureTests.scala
@@ -11,14 +11,17 @@ class ProgramStructureTests extends WordSpec with Matchers {
 
     "contain <global> namespace block node" in {
       val namespaceBlocks =
-        fixture.V.hasLabel(NodeType.NAMESPACE_BLOCK.toString)
-        .has(NodeKeys.FULL_NAME -> Defines.globalNamespaceName).l
+        fixture.V
+          .hasLabel(NodeType.NAMESPACE_BLOCK.toString)
+          .has(NodeKeys.FULL_NAME -> Defines.globalNamespaceName)
+          .l
 
       namespaceBlocks.size shouldBe 1
     }
 
     "contain one file node" in {
-      val fileName = fixture.V.hasLabel(NodeType.FILE.toString)
+      val fileName = fixture.V
+        .hasLabel(NodeType.FILE.toString)
         .value(NodeKeys.NAME)
         .headOption
       fileName.isDefined shouldBe true
@@ -26,9 +29,11 @@ class ProgramStructureTests extends WordSpec with Matchers {
     }
 
     "contain AST edge from file node to namespace block" in {
-      val nodes = fixture.V.hasLabel(NodeType.FILE.toString)
+      val nodes = fixture.V
+        .hasLabel(NodeType.FILE.toString)
         .out("AST")
-        .hasLabel(NodeType.NAMESPACE_BLOCK.toString).l
+        .hasLabel(NodeType.NAMESPACE_BLOCK.toString)
+        .l
       nodes.size shouldBe 1
     }
 
@@ -36,7 +41,6 @@ class ProgramStructureTests extends WordSpec with Matchers {
       val nodes = fixture.V.hasLabel(NodeType.TYPE_DECL.toString).l
       nodes.size should be > 0
     }
-
 
   }
 

--- a/src/test/scala/io/shiftleft/fuzzyc2cpg/TestTest.scala
+++ b/src/test/scala/io/shiftleft/fuzzyc2cpg/TestTest.scala
@@ -7,7 +7,7 @@ class TestTest extends WordSpec with Matchers {
 
   "Tests" should {
     "load graphs" in {
-      fixture.V.l.size should be  > 0
+      fixture.V.l.size should be > 0
     }
   }
 

--- a/src/test/scala/io/shiftleft/fuzzyc2cpg/TraversalUtils.scala
+++ b/src/test/scala/io/shiftleft/fuzzyc2cpg/TraversalUtils.scala
@@ -17,5 +17,4 @@ trait TraversalUtils extends Matchers {
     result
   }
 
-
 }

--- a/src/test/scala/io/shiftleft/fuzzyc2cpg/TypeDeclTests.scala
+++ b/src/test/scala/io/shiftleft/fuzzyc2cpg/TypeDeclTests.scala
@@ -9,7 +9,8 @@ class TypeDeclTests extends WordSpec with Matchers {
 
   "Type decl test project" should {
     "contain one internal type decl node for Foo" in {
-      val typeDeclNodes = fixture.V.hasLabel(NodeType.TYPE_DECL.toString)
+      val typeDeclNodes = fixture.V
+        .hasLabel(NodeType.TYPE_DECL.toString)
         .has(NodeKeys.NAME -> "Foo")
         .l
       typeDeclNodes.size shouldBe 1
@@ -21,8 +22,11 @@ class TypeDeclTests extends WordSpec with Matchers {
     }
 
     "contain edges from Foo to three members" in {
-      val members = fixture.V.hasLabel(NodeType.TYPE_DECL.toString)
-        .out("AST").hasLabel(NodeType.MEMBER.toString).l
+      val members = fixture.V
+        .hasLabel(NodeType.TYPE_DECL.toString)
+        .out("AST")
+        .hasLabel(NodeType.MEMBER.toString)
+        .l
       members.size shouldBe 3
     }
 

--- a/src/test/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgTests.scala
+++ b/src/test/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgTests.scala
@@ -323,6 +323,7 @@ class AstToCpgTests extends WordSpec with Matchers {
       block.checkForSingle()
 
       val whileStmt = block.expandAst(NodeTypes.CONDITION)
+      whileStmt.check(1, _.value2(NodeKeys.CODE), expectations = "x < 1")
       whileStmt.check(1, whileStmt => whileStmt.value2(NodeKeys.PARSER_TYPE_NAME),
         expectations = "WhileStatement")
 
@@ -392,6 +393,7 @@ class AstToCpgTests extends WordSpec with Matchers {
       val elseStmt = ifStmt.expandAst(NodeTypes.CONDITION)
       elseStmt.check(1, _.value2(NodeKeys.PARSER_TYPE_NAME),
         expectations = "ElseStatement")
+      elseStmt.check(1, _.value2(NodeKeys.CODE), "!(x > 0)")
 
       val elseBlock = elseStmt.expandAst(NodeTypes.BLOCK)
       elseBlock.checkForSingle()
@@ -412,7 +414,8 @@ class AstToCpgTests extends WordSpec with Matchers {
       block.checkForSingle()
       val call = block.expandAst(NodeTypes.CALL)
       val condition = call.expandAst(NodeTypes.CONDITION)
-      condition.check(1, _.value2(NodeKeys.CODE), expectations = "(foo == 1) ? bar : 0")
+      condition.check(1, _.value2(NodeKeys.CODE), expectations = "foo == 1")
+      condition.check(1, _.value2(NodeKeys.PARSER_TYPE_NAME), expectations = "ConditionalExpression")
     }
 
     "be correct for for-loop with multiple initializations" in new Fixture(
@@ -430,6 +433,7 @@ class AstToCpgTests extends WordSpec with Matchers {
       val forLoop = block.expandAst(NodeTypes.CONDITION)
       forLoop.check(1, _.value2(NodeKeys.PARSER_TYPE_NAME),
         expectations = "ForStatement")
+      forLoop.check(1, _.value2(NodeKeys.CODE), expectations = "x < 1")
 
       val initBlock = forLoop.expandAst(NodeTypes.BLOCK).filterOrder(1)
       initBlock.checkForSingle()

--- a/src/test/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgTests.scala
+++ b/src/test/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgTests.scala
@@ -322,7 +322,7 @@ class AstToCpgTests extends WordSpec with Matchers {
       val block = method.expandAst(NodeTypes.BLOCK)
       block.checkForSingle()
 
-      val whileStmt = block.expandAst(NodeTypes.UNKNOWN)
+      val whileStmt = block.expandAst(NodeTypes.CONDITION)
       whileStmt.check(1, whileStmt => whileStmt.value2(NodeKeys.PARSER_TYPE_NAME),
         expectations = "WhileStatement")
 
@@ -348,7 +348,7 @@ class AstToCpgTests extends WordSpec with Matchers {
       val method = getMethod("method")
       val block = method.expandAst(NodeTypes.BLOCK)
       block.checkForSingle()
-      val ifStmt = block.expandAst(NodeTypes.UNKNOWN)
+      val ifStmt = block.expandAst(NodeTypes.CONDITION)
       ifStmt.check(1, _.value2(NodeKeys.PARSER_TYPE_NAME),
         expectations = "IfStatement")
 
@@ -376,7 +376,7 @@ class AstToCpgTests extends WordSpec with Matchers {
       val method = getMethod("method")
       val block = method.expandAst(NodeTypes.BLOCK)
       block.checkForSingle()
-      val ifStmt = block.expandAst(NodeTypes.UNKNOWN)
+      val ifStmt = block.expandAst(NodeTypes.CONDITION)
       ifStmt.check(1, _.value2(NodeKeys.PARSER_TYPE_NAME),
         expectations = "IfStatement")
 
@@ -389,7 +389,7 @@ class AstToCpgTests extends WordSpec with Matchers {
       val assignment = ifBlock.expandAst(NodeTypes.CALL)
       assignment.checkForSingle(NodeKeys.NAME, Operators.assignment)
 
-      val elseStmt = ifStmt.expandAst(NodeTypes.UNKNOWN)
+      val elseStmt = ifStmt.expandAst(NodeTypes.CONDITION)
       elseStmt.check(1, _.value2(NodeKeys.PARSER_TYPE_NAME),
         expectations = "ElseStatement")
 
@@ -400,7 +400,22 @@ class AstToCpgTests extends WordSpec with Matchers {
       assignmentInElse.checkForSingle(NodeKeys.NAME, Operators.assignment)
     }
 
-    "be correct for for-loop with multiple initalizations" in new Fixture(
+    "be correct for conditional expression" in new Fixture(
+      """
+        | void method() {
+        |   int x = (foo == 1) ? bar : 0;
+        | }
+      """.stripMargin
+    ) {
+      val method = getMethod("method")
+      val block = method.expandAst(NodeTypes.BLOCK)
+      block.checkForSingle()
+      val call = block.expandAst(NodeTypes.CALL)
+      val condition = call.expandAst(NodeTypes.CONDITION)
+      condition.check(1, _.value2(NodeKeys.CODE), expectations = "(foo == 1) ? bar : 0")
+    }
+
+    "be correct for for-loop with multiple initializations" in new Fixture(
       """
         |void method(int x, int y) {
         |  for ( x = 0, y = 0; x < 1; x += 1) {
@@ -412,7 +427,7 @@ class AstToCpgTests extends WordSpec with Matchers {
       val block = method.expandAst(NodeTypes.BLOCK)
       block.checkForSingle()
 
-      val forLoop = block.expandAst(NodeTypes.UNKNOWN)
+      val forLoop = block.expandAst(NodeTypes.CONDITION)
       forLoop.check(1, _.value2(NodeKeys.PARSER_TYPE_NAME),
         expectations = "ForStatement")
 

--- a/src/test/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgTests.scala
+++ b/src/test/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgTests.scala
@@ -318,8 +318,8 @@ class AstToCpgTests extends WordSpec with Matchers {
       val block = method.expandAst(NodeTypes.BLOCK)
       block.checkForSingle()
 
-      val whileStmt = block.expandAst(NodeTypes.CONDITION)
-      whileStmt.check(1, _.value2(NodeKeys.CODE), expectations = "x < 1")
+      val whileStmt = block.expandAst(NodeTypes.CONTROL_STRUCTURE)
+      whileStmt.check(1, _.value2(NodeKeys.CODE), expectations = "while (x < 1)")
       whileStmt.check(1, whileStmt => whileStmt.value2(NodeKeys.PARSER_TYPE_NAME), expectations = "WhileStatement")
 
       val lessThan = whileStmt.expandAst(NodeTypes.CALL)
@@ -343,7 +343,7 @@ class AstToCpgTests extends WordSpec with Matchers {
       val method = getMethod("method")
       val block = method.expandAst(NodeTypes.BLOCK)
       block.checkForSingle()
-      val ifStmt = block.expandAst(NodeTypes.CONDITION)
+      val ifStmt = block.expandAst(NodeTypes.CONTROL_STRUCTURE)
       ifStmt.check(1, _.value2(NodeKeys.PARSER_TYPE_NAME), expectations = "IfStatement")
 
       val greaterThan = ifStmt.expandAst(NodeTypes.CALL)
@@ -369,7 +369,7 @@ class AstToCpgTests extends WordSpec with Matchers {
       val method = getMethod("method")
       val block = method.expandAst(NodeTypes.BLOCK)
       block.checkForSingle()
-      val ifStmt = block.expandAst(NodeTypes.CONDITION)
+      val ifStmt = block.expandAst(NodeTypes.CONTROL_STRUCTURE)
       ifStmt.check(1, _.value2(NodeKeys.PARSER_TYPE_NAME), expectations = "IfStatement")
 
       val greaterThan = ifStmt.expandAst(NodeTypes.CALL)
@@ -381,9 +381,9 @@ class AstToCpgTests extends WordSpec with Matchers {
       val assignment = ifBlock.expandAst(NodeTypes.CALL)
       assignment.checkForSingle(NodeKeys.NAME, Operators.assignment)
 
-      val elseStmt = ifStmt.expandAst(NodeTypes.CONDITION)
+      val elseStmt = ifStmt.expandAst(NodeTypes.CONTROL_STRUCTURE)
       elseStmt.check(1, _.value2(NodeKeys.PARSER_TYPE_NAME), expectations = "ElseStatement")
-      elseStmt.check(1, _.value2(NodeKeys.CODE), "!(x > 0)")
+      elseStmt.check(1, _.value2(NodeKeys.CODE), "else")
 
       val elseBlock = elseStmt.expandAst(NodeTypes.BLOCK)
       elseBlock.checkForSingle()
@@ -403,8 +403,8 @@ class AstToCpgTests extends WordSpec with Matchers {
       val block = method.expandAst(NodeTypes.BLOCK)
       block.checkForSingle()
       val call = block.expandAst(NodeTypes.CALL)
-      val condition = call.expandAst(NodeTypes.CONDITION)
-      condition.check(1, _.value2(NodeKeys.CODE), expectations = "foo == 1")
+      val condition = call.expandAst(NodeTypes.CONTROL_STRUCTURE)
+      condition.check(1, _.value2(NodeKeys.CODE), expectations = "(foo == 1) ? bar : 0")
       condition.check(1, _.value2(NodeKeys.PARSER_TYPE_NAME), expectations = "ConditionalExpression")
     }
 
@@ -419,9 +419,9 @@ class AstToCpgTests extends WordSpec with Matchers {
       val block = method.expandAst(NodeTypes.BLOCK)
       block.checkForSingle()
 
-      val forLoop = block.expandAst(NodeTypes.CONDITION)
+      val forLoop = block.expandAst(NodeTypes.CONTROL_STRUCTURE)
       forLoop.check(1, _.value2(NodeKeys.PARSER_TYPE_NAME), expectations = "ForStatement")
-      forLoop.check(1, _.value2(NodeKeys.CODE), expectations = "x < 1")
+      forLoop.check(1, _.value2(NodeKeys.CODE), expectations = "for ( x = 0, y = 0; x < 1; x += 1)")
 
       val initBlock = forLoop.expandAst(NodeTypes.BLOCK).filterOrder(1)
       initBlock.checkForSingle()

--- a/src/test/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgTests.scala
+++ b/src/test/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgTests.scala
@@ -63,9 +63,7 @@ class AstToCpgTests extends WordSpec with Matchers {
       vertexList.size shouldBe 1
     }
 
-    def check[A](count: Int,
-                 mapFunc: Vertex => A,
-                 expectations: A*): Unit = {
+    def check[A](count: Int, mapFunc: Vertex => A, expectations: A*): Unit = {
       vertexList.size shouldBe count
       vertexList.map(mapFunc).toSet shouldBe expectations.toSet
     }
@@ -132,29 +130,29 @@ class AstToCpgTests extends WordSpec with Matchers {
   }
 
   "Method AST layout" should {
-    "be correct for empty method" in new Fixture(
-      """
+    "be correct for empty method" in new Fixture("""
         |void method(int x) {
         |}"
       """.stripMargin) {
       val method = getMethod("method")
       method.expandAst(NodeTypes.BLOCK).checkForSingle()
 
-      method.expandAst(NodeTypes.METHOD_RETURN)
+      method
+        .expandAst(NodeTypes.METHOD_RETURN)
         .checkForSingle(NodeKeys.TYPE_FULL_NAME, "void")
 
-      method.expandAst(NodeTypes.METHOD_PARAMETER_IN)
+      method
+        .expandAst(NodeTypes.METHOD_PARAMETER_IN)
         .checkForSingle(NodeKeys.TYPE_FULL_NAME, "int")
     }
 
-    "be correct for decl assignment" in new Fixture(
-      """
+    "be correct for decl assignment" in new Fixture("""
         |void method() {
         |  int local = 1;
         |}
       """.stripMargin) {
       val method = getMethod("method")
-      val block= method.expandAst(NodeTypes.BLOCK)
+      val block = method.expandAst(NodeTypes.BLOCK)
       block.checkForSingle()
 
       val local = block.expandAst(NodeTypes.LOCAL)
@@ -165,26 +163,26 @@ class AstToCpgTests extends WordSpec with Matchers {
       assignment.checkForSingle(NodeKeys.NAME, Operators.assignment)
 
       val arguments = assignment.expandAst()
-      arguments.check(2,
+      arguments.check(
+        2,
         arg =>
           (arg.label,
-            arg.value2(NodeKeys.CODE),
-            arg.value2(NodeKeys.TYPE_FULL_NAME),
-            arg.value2(NodeKeys.ORDER),
-            arg.value2(NodeKeys.ARGUMENT_INDEX)),
-        expectations =
-          (NodeTypes.IDENTIFIER, "local", "int", 1, 1),
-        (NodeTypes.LITERAL, "1", "int", 2, 2))
+           arg.value2(NodeKeys.CODE),
+           arg.value2(NodeKeys.TYPE_FULL_NAME),
+           arg.value2(NodeKeys.ORDER),
+           arg.value2(NodeKeys.ARGUMENT_INDEX)),
+        expectations = (NodeTypes.IDENTIFIER, "local", "int", 1, 1),
+        (NodeTypes.LITERAL, "1", "int", 2, 2)
+      )
     }
 
-    "be correct for decl assignment with identifier on right hand side" in new Fixture(
-      """
+    "be correct for decl assignment with identifier on right hand side" in new Fixture("""
         |void method(int x) {
         |  int local = x;
         |}
       """.stripMargin) {
       val method = getMethod("method")
-      val block= method.expandAst(NodeTypes.BLOCK)
+      val block = method.expandAst(NodeTypes.BLOCK)
       block.checkForSingle()
 
       val local = block.expandAst(NodeTypes.LOCAL)
@@ -195,68 +193,71 @@ class AstToCpgTests extends WordSpec with Matchers {
       assignment.checkForSingle(NodeKeys.NAME, Operators.assignment)
 
       val arguments = assignment.expandAst()
-      arguments.check(2,
+      arguments.check(
+        2,
         arg =>
           (arg.label,
-            arg.value2(NodeKeys.CODE),
-            arg.value2(NodeKeys.TYPE_FULL_NAME),
-            arg.value2(NodeKeys.ORDER),
-            arg.value2(NodeKeys.ARGUMENT_INDEX)),
-        expectations =
-          (NodeTypes.IDENTIFIER, "local", "int", 1, 1),
-        (NodeTypes.IDENTIFIER, "x", "int", 2, 2))
+           arg.value2(NodeKeys.CODE),
+           arg.value2(NodeKeys.TYPE_FULL_NAME),
+           arg.value2(NodeKeys.ORDER),
+           arg.value2(NodeKeys.ARGUMENT_INDEX)),
+        expectations = (NodeTypes.IDENTIFIER, "local", "int", 1, 1),
+        (NodeTypes.IDENTIFIER, "x", "int", 2, 2)
+      )
     }
 
-    "be correct for decl assignment of multiple locals" in new Fixture(
-      """
+    "be correct for decl assignment of multiple locals" in new Fixture("""
         |void method(int x, int y) {
         |  int local = x, local2 = y;
         |}
       """.stripMargin) {
       val method = getMethod("method")
-      val block= method.expandAst(NodeTypes.BLOCK)
+      val block = method.expandAst(NodeTypes.BLOCK)
       block.checkForSingle()
 
-      block.expandAst(NodeTypes.LOCAL).check(2,
-        local =>
-          (local.label, local.value2(NodeKeys.CODE), local.value2(NodeKeys.TYPE_FULL_NAME)),
-        expectations =
-          (NodeTypes.LOCAL, "local", "int"),
-        (NodeTypes.LOCAL, "local2", "int"))
+      block
+        .expandAst(NodeTypes.LOCAL)
+        .check(
+          2,
+          local => (local.label, local.value2(NodeKeys.CODE), local.value2(NodeKeys.TYPE_FULL_NAME)),
+          expectations = (NodeTypes.LOCAL, "local", "int"),
+          (NodeTypes.LOCAL, "local2", "int")
+        )
 
       val assignment1 = block.expandAst(NodeTypes.CALL).filterOrder(1)
       assignment1.checkForSingle(NodeKeys.NAME, Operators.assignment)
 
       val arguments1 = assignment1.expandAst()
-      arguments1.check(2,
+      arguments1.check(
+        2,
         arg =>
           (arg.label,
-            arg.value2(NodeKeys.CODE),
-            arg.value2(NodeKeys.TYPE_FULL_NAME),
-            arg.value2(NodeKeys.ORDER),
-            arg.value2(NodeKeys.ARGUMENT_INDEX)),
-        expectations =
-          (NodeTypes.IDENTIFIER, "local", "int", 1, 1),
-        (NodeTypes.IDENTIFIER, "x", "int", 2, 2))
+           arg.value2(NodeKeys.CODE),
+           arg.value2(NodeKeys.TYPE_FULL_NAME),
+           arg.value2(NodeKeys.ORDER),
+           arg.value2(NodeKeys.ARGUMENT_INDEX)),
+        expectations = (NodeTypes.IDENTIFIER, "local", "int", 1, 1),
+        (NodeTypes.IDENTIFIER, "x", "int", 2, 2)
+      )
 
       val assignment2 = block.expandAst(NodeTypes.CALL).filterOrder(2)
       assignment2.checkForSingle(NodeKeys.NAME, Operators.assignment)
 
       val arguments2 = assignment2.expandAst()
-      arguments2.check(2,
+      arguments2.check(
+        2,
         arg =>
           (arg.label,
-            arg.value2(NodeKeys.CODE),
-            arg.value2(NodeKeys.TYPE_FULL_NAME),
-            arg.value2(NodeKeys.ORDER),
-            arg.value2(NodeKeys.ARGUMENT_INDEX)),
-        expectations =
-          (NodeTypes.IDENTIFIER, "local2", "int", 1, 1),
-        (NodeTypes.IDENTIFIER, "y", "int", 2, 2))
+           arg.value2(NodeKeys.CODE),
+           arg.value2(NodeKeys.TYPE_FULL_NAME),
+           arg.value2(NodeKeys.ORDER),
+           arg.value2(NodeKeys.ARGUMENT_INDEX)),
+        expectations = (NodeTypes.IDENTIFIER, "local2", "int", 1, 1),
+        (NodeTypes.IDENTIFIER, "y", "int", 2, 2)
+      )
     }
 
-    "be correct for nested expression" in new Fixture(
-      """
+    "be correct for nested expression" in new Fixture("""
         |void method() {
         |  int x;
         |  int y;
@@ -269,8 +270,7 @@ class AstToCpgTests extends WordSpec with Matchers {
       val block = method.expandAst(NodeTypes.BLOCK)
       block.checkForSingle()
       val locals = block.expandAst(NodeTypes.LOCAL)
-      locals.check(3, local => local.value2(NodeKeys.NAME),
-        expectations = "x", "y", "z")
+      locals.check(3, local => local.value2(NodeKeys.NAME), expectations = "x", "y", "z")
 
       val assignment = block.expandAst(NodeTypes.CALL)
       assignment.checkForSingle(NodeKeys.NAME, Operators.assignment)
@@ -279,18 +279,15 @@ class AstToCpgTests extends WordSpec with Matchers {
       rightHandSide.checkForSingle(NodeKeys.NAME, Operators.addition)
 
       val arguments = rightHandSide.expandAst()
-      arguments.check(2, arg =>
-        (arg.label,
-          arg.value2(NodeKeys.CODE),
-          arg.value2(NodeKeys.ORDER),
-          arg.value2(NodeKeys.ARGUMENT_INDEX)),
+      arguments.check(
+        2,
+        arg => (arg.label, arg.value2(NodeKeys.CODE), arg.value2(NodeKeys.ORDER), arg.value2(NodeKeys.ARGUMENT_INDEX)),
         expectations = (NodeTypes.IDENTIFIER, "y", 1, 1),
         (NodeTypes.IDENTIFIER, "z", 2, 2)
       )
     }
 
-    "be correct for nested block" in new Fixture (
-      """
+    "be correct for nested block" in new Fixture("""
         |void method() {
         |  int x;
         |  {
@@ -310,8 +307,7 @@ class AstToCpgTests extends WordSpec with Matchers {
       nestedLocals.checkForSingle(NodeKeys.NAME, "y")
     }
 
-    "be correct for while-loop" in new Fixture(
-      """
+    "be correct for while-loop" in new Fixture("""
         |void method(int x) {
         |  while (x < 1) {
         |    x += 1;
@@ -324,8 +320,7 @@ class AstToCpgTests extends WordSpec with Matchers {
 
       val whileStmt = block.expandAst(NodeTypes.CONDITION)
       whileStmt.check(1, _.value2(NodeKeys.CODE), expectations = "x < 1")
-      whileStmt.check(1, whileStmt => whileStmt.value2(NodeKeys.PARSER_TYPE_NAME),
-        expectations = "WhileStatement")
+      whileStmt.check(1, whileStmt => whileStmt.value2(NodeKeys.PARSER_TYPE_NAME), expectations = "WhileStatement")
 
       val lessThan = whileStmt.expandAst(NodeTypes.CALL)
       lessThan.checkForSingle(NodeKeys.NAME, Operators.lessThan)
@@ -337,8 +332,7 @@ class AstToCpgTests extends WordSpec with Matchers {
       assignPlus.filterOrder(1).checkForSingle(NodeKeys.NAME, Operators.assignmentPlus)
     }
 
-    "be correct for if" in new Fixture(
-      """
+    "be correct for if" in new Fixture("""
         |void method(int x) {
         |  int y;
         |  if (x > 0) {
@@ -350,8 +344,7 @@ class AstToCpgTests extends WordSpec with Matchers {
       val block = method.expandAst(NodeTypes.BLOCK)
       block.checkForSingle()
       val ifStmt = block.expandAst(NodeTypes.CONDITION)
-      ifStmt.check(1, _.value2(NodeKeys.PARSER_TYPE_NAME),
-        expectations = "IfStatement")
+      ifStmt.check(1, _.value2(NodeKeys.PARSER_TYPE_NAME), expectations = "IfStatement")
 
       val greaterThan = ifStmt.expandAst(NodeTypes.CALL)
       greaterThan.checkForSingle(NodeKeys.NAME, Operators.greaterThan)
@@ -363,8 +356,7 @@ class AstToCpgTests extends WordSpec with Matchers {
       assignment.checkForSingle(NodeKeys.NAME, Operators.assignment)
     }
 
-    "be correct for if-else" in new Fixture(
-      """
+    "be correct for if-else" in new Fixture("""
         |void method(int x) {
         |  int y;
         |  if (x > 0) {
@@ -378,8 +370,7 @@ class AstToCpgTests extends WordSpec with Matchers {
       val block = method.expandAst(NodeTypes.BLOCK)
       block.checkForSingle()
       val ifStmt = block.expandAst(NodeTypes.CONDITION)
-      ifStmt.check(1, _.value2(NodeKeys.PARSER_TYPE_NAME),
-        expectations = "IfStatement")
+      ifStmt.check(1, _.value2(NodeKeys.PARSER_TYPE_NAME), expectations = "IfStatement")
 
       val greaterThan = ifStmt.expandAst(NodeTypes.CALL)
       greaterThan.checkForSingle(NodeKeys.NAME, Operators.greaterThan)
@@ -391,8 +382,7 @@ class AstToCpgTests extends WordSpec with Matchers {
       assignment.checkForSingle(NodeKeys.NAME, Operators.assignment)
 
       val elseStmt = ifStmt.expandAst(NodeTypes.CONDITION)
-      elseStmt.check(1, _.value2(NodeKeys.PARSER_TYPE_NAME),
-        expectations = "ElseStatement")
+      elseStmt.check(1, _.value2(NodeKeys.PARSER_TYPE_NAME), expectations = "ElseStatement")
       elseStmt.check(1, _.value2(NodeKeys.CODE), "!(x > 0)")
 
       val elseBlock = elseStmt.expandAst(NodeTypes.BLOCK)
@@ -418,8 +408,7 @@ class AstToCpgTests extends WordSpec with Matchers {
       condition.check(1, _.value2(NodeKeys.PARSER_TYPE_NAME), expectations = "ConditionalExpression")
     }
 
-    "be correct for for-loop with multiple initializations" in new Fixture(
-      """
+    "be correct for for-loop with multiple initializations" in new Fixture("""
         |void method(int x, int y) {
         |  for ( x = 0, y = 0; x < 1; x += 1) {
         |    int z = 0;
@@ -431,16 +420,14 @@ class AstToCpgTests extends WordSpec with Matchers {
       block.checkForSingle()
 
       val forLoop = block.expandAst(NodeTypes.CONDITION)
-      forLoop.check(1, _.value2(NodeKeys.PARSER_TYPE_NAME),
-        expectations = "ForStatement")
+      forLoop.check(1, _.value2(NodeKeys.PARSER_TYPE_NAME), expectations = "ForStatement")
       forLoop.check(1, _.value2(NodeKeys.CODE), expectations = "x < 1")
 
       val initBlock = forLoop.expandAst(NodeTypes.BLOCK).filterOrder(1)
       initBlock.checkForSingle()
 
       val assignments = initBlock.expandAst(NodeTypes.CALL)
-      assignments.check(2, _.value2(NodeKeys.NAME),
-        expectations = Operators.assignment)
+      assignments.check(2, _.value2(NodeKeys.NAME), expectations = Operators.assignment)
 
       val condition = forLoop.expandAst(NodeTypes.CALL).filterOrder(2)
       condition.checkForSingle(NodeKeys.NAME, Operators.lessThan)
@@ -452,8 +439,7 @@ class AstToCpgTests extends WordSpec with Matchers {
       forBlock.checkForSingle()
     }
 
-    "be correct for unary expression '+'" in new Fixture(
-      """
+    "be correct for unary expression '+'" in new Fixture("""
         |void method(int x) {
         |  +x;
         |}
@@ -469,8 +455,7 @@ class AstToCpgTests extends WordSpec with Matchers {
       identifierX.checkForSingle(NodeKeys.NAME, "x")
     }
 
-    "be correct for unary expression '++'" in new Fixture(
-      """
+    "be correct for unary expression '++'" in new Fixture("""
         |void method(int x) {
         |  ++x;
         |}
@@ -486,8 +471,7 @@ class AstToCpgTests extends WordSpec with Matchers {
       identifierX.checkForSingle(NodeKeys.NAME, "x")
     }
 
-    "be correct for call expression" in new Fixture(
-      """
+    "be correct for call expression" in new Fixture("""
         |void method(int x) {
         |  foo(x);
         |}
@@ -503,16 +487,13 @@ class AstToCpgTests extends WordSpec with Matchers {
       argumentX.checkForSingle(NodeKeys.NAME, "x")
     }
 
-    "be correct for pointer call expression" in new Fixture(
-      """
+    "be correct for pointer call expression" in new Fixture("""
         |void method(int x) {
         |  (*funcPointer)(x);
         |}
-      """.stripMargin) {
-    }
+      """.stripMargin) {}
 
-    "be correct for member access" in new Fixture(
-      """
+    "be correct for member access" in new Fixture("""
         |void method(struct someUndefinedStruct x) {
         |  x.a;
         |}
@@ -525,16 +506,12 @@ class AstToCpgTests extends WordSpec with Matchers {
       memberAccess.checkForSingle(NodeKeys.NAME, Operators.memberAccess)
 
       val arguments = memberAccess.expandAst(NodeTypes.IDENTIFIER)
-      arguments.check(2,
-        arg => {
-          (arg.value2(NodeKeys.NAME), arg.value2(NodeKeys.ARGUMENT_INDEX))
-        },
-        expectations = ("x", 1), ("a", 2)
-      )
+      arguments.check(2, arg => {
+        (arg.value2(NodeKeys.NAME), arg.value2(NodeKeys.ARGUMENT_INDEX))
+      }, expectations = ("x", 1), ("a", 2))
     }
 
-    "be correct for indirect member access" in new Fixture(
-      """
+    "be correct for indirect member access" in new Fixture("""
         |void method(struct someUndefinedStruct *x) {
         |  x->a;
         |}
@@ -547,12 +524,9 @@ class AstToCpgTests extends WordSpec with Matchers {
       memberAccess.checkForSingle(NodeKeys.NAME, Operators.indirectMemberAccess)
 
       val arguments = memberAccess.expandAst(NodeTypes.IDENTIFIER)
-      arguments.check(2,
-        arg => {
-          (arg.value2(NodeKeys.NAME), arg.value2(NodeKeys.ARGUMENT_INDEX))
-        },
-        expectations = ("x", 1), ("a", 2)
-      )
+      arguments.check(2, arg => {
+        (arg.value2(NodeKeys.NAME), arg.value2(NodeKeys.ARGUMENT_INDEX))
+      }, expectations = ("x", 1), ("a", 2))
     }
 
     "be correct for sizeof operator on identifier with brackets" in new Fixture(
@@ -619,8 +593,7 @@ class AstToCpgTests extends WordSpec with Matchers {
   }
 
   "Structural AST layout" should {
-    "be correct for empty method" in new Fixture(
-      """
+    "be correct for empty method" in new Fixture("""
         | void method() {
         | };
       """.stripMargin) {
@@ -630,8 +603,7 @@ class AstToCpgTests extends WordSpec with Matchers {
       astParent.expandAst(NodeTypes.METHOD) shouldBe method
     }
 
-    "be correct for empty named struct" in new Fixture(
-      """
+    "be correct for empty named struct" in new Fixture("""
         | struct foo {
         | };
       """.stripMargin) {
@@ -641,8 +613,7 @@ class AstToCpgTests extends WordSpec with Matchers {
       astParent.expandAst(NodeTypes.TYPE_DECL) shouldBe typeDecl
     }
 
-    "be correct for named struct with single field" in new Fixture(
-      """
+    "be correct for named struct with single field" in new Fixture("""
         | struct foo {
         |   int x;
         | };
@@ -655,8 +626,7 @@ class AstToCpgTests extends WordSpec with Matchers {
       member.checkForSingle(NodeKeys.TYPE_FULL_NAME, "int")
     }
 
-    "be correct for named struct with multiple fields" in new Fixture(
-      """
+    "be correct for named struct with multiple fields" in new Fixture("""
         | struct foo {
         |   int x;
         |   int y;
@@ -666,12 +636,10 @@ class AstToCpgTests extends WordSpec with Matchers {
       val typeDecl = getTypeDecl("foo")
       typeDecl.checkForSingle()
       val member = typeDecl.expandAst(NodeTypes.MEMBER)
-      member.check(3, member => member.value2(NodeKeys.CODE),
-        expectations = "x", "y", "z")
+      member.check(3, member => member.value2(NodeKeys.CODE), expectations = "x", "y", "z")
     }
 
-    "be correct for named struct with nested struct" in new Fixture(
-      """
+    "be correct for named struct with nested struct" in new Fixture("""
         | struct foo {
         |   int x;
         |   struct bar {
@@ -713,8 +681,7 @@ class AstToCpgTests extends WordSpec with Matchers {
   }
 
   "AST" should {
-    "have correct line number for method content" in new Fixture(
-      """
+    "have correct line number for method content" in new Fixture("""
         |
         |
         |

--- a/src/test/scala/io/shiftleft/fuzzyc2cpg/cfg/AstToCfgTests.scala
+++ b/src/test/scala/io/shiftleft/fuzzyc2cpg/cfg/AstToCfgTests.scala
@@ -56,10 +56,10 @@ class AstToCfgTests extends WordSpec with Matchers {
     codeToCpgNode += entry.code -> entry
     codeToCpgNode += exit.code -> exit
 
-
     def expected(pairs: (String, CfgEdgeType)*): Set[CfgNodeEdgePair] = {
-      pairs.map { case (code, cfgEdgeType) =>
-        CfgNodeEdgePair(codeToCpgNode(code), cfgEdgeType)
+      pairs.map {
+        case (code, cfgEdgeType) =>
+          CfgNodeEdgePair(codeToCpgNode(code), cfgEdgeType)
       }.toSet
     }
 
@@ -133,8 +133,8 @@ class AstToCfgTests extends WordSpec with Matchers {
         succOf("++x") shouldBe expected(("EXIT", AlwaysEdge))
       }
 
-     // TODO This is wrong but intention, see comment on
-     // visitor function for ConditionExpression.
+    // TODO This is wrong but intention, see comment on
+    // visitor function for ConditionExpression.
     "be correct for conditional expression" in
       new Fixture("x ? y : z;") {
         succOf("ENTRY") shouldBe expected(("x", AlwaysEdge))


### PR DESCRIPTION
We previously only emitted "UNKNOWN" nodes for control structures such as if, while, or for. We now emit CONTROL_STRUCTURE nodes instead, making it possible to identify conditions as first children of these control structures.