### PR TITLE
upgrade to scala 2.13.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,20 +1,21 @@
 name := "fuzzyc2cpg"
 organization := "io.shiftleft"
-scalaVersion := "2.12.7"
+scalaVersion := "2.13.0"
 
-val cpgVersion = "0.9.331"
+val cpgVersion = "0.9.331a"
 
 libraryDependencies ++= Seq(
-  "com.github.scopt"   %% "scopt"          % "3.7.0",
+  "io.shiftleft" %% "codepropertygraph" % cpgVersion,
+  "io.shiftleft" %% "codepropertygraph-protos" % cpgVersion,
+  "com.github.scopt" %% "scopt" % "3.7.1",
   "org.antlr" % "antlr4-runtime" % "4.7.2",
-  "io.shiftleft" % "codepropertygraph" % cpgVersion,
-  "io.shiftleft" % "codepropertygraph-protos" % cpgVersion,
   "org.slf4j" % "slf4j-simple" % "1.7.25" % Runtime,
   "commons-cli" % "commons-cli" % "1.4",
-  "com.github.pathikrit" %% "better-files"  % "3.1.0",
+  "com.github.pathikrit" %% "better-files"  % "3.8.0",
+  "org.scala-lang.modules" %% "scala-parallel-collections" % "0.2.0",
   "com.novocode" % "junit-interface" % "0.11" % Test,
   "junit" % "junit" % "4.12" % Test,
-  "org.scalatest" %% "scalatest" % "3.0.3" % Test,
+  "org.scalatest" %% "scalatest" % "3.0.8" % Test,
 )
 
 // uncomment if you want to use a cpg version that has *just* been released

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=1.2.6
+sbt.version=1.2.8
 

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory
 import io.shiftleft.fuzzyc2cpg.Utils._
 import io.shiftleft.fuzzyc2cpg.output.CpgOutputModuleFactory
 import io.shiftleft.fuzzyc2cpg.parser.modules.AntlrCModuleParserDriver
+import scala.collection.parallel.CollectionConverters._
 
 class FuzzyC2Cpg(outputModuleFactory: CpgOutputModuleFactory) {
 

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgConverter.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgConverter.scala
@@ -18,8 +18,7 @@ import io.shiftleft.fuzzyc2cpg.astnew.NodeProperty.NodeProperty
 import io.shiftleft.fuzzyc2cpg.scope.Scope
 import io.shiftleft.proto.cpg.Cpg.DispatchTypes
 import org.slf4j.LoggerFactory
-
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 object AstToCpgConverter {
   private val logger = LoggerFactory.getLogger(getClass)

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/CpgAdapter.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/CpgAdapter.scala
@@ -27,11 +27,11 @@ trait CpgAdapter[NodeBuilderType, NodeType] {
 
   def createNode(nodeBuilder: NodeBuilderType): NodeType
 
-  def addProperty(nodeBuilder: NodeBuilderType, property: NodeProperty, value: String)
+  def addProperty(nodeBuilder: NodeBuilderType, property: NodeProperty, value: String): Unit
 
-  def addProperty(nodeBuilder: NodeBuilderType, property: NodeProperty, value: Int)
+  def addProperty(nodeBuilder: NodeBuilderType, property: NodeProperty, value: Int): Unit
 
-  def addProperty(nodeBuilder: NodeBuilderType, property: NodeProperty, value: Boolean)
+  def addProperty(nodeBuilder: NodeBuilderType, property: NodeProperty, value: Boolean): Unit
 
-  def addEdge(edgeKind: EdgeKind, dstNode: NodeType, srcNode: NodeType)
+  def addEdge(edgeKind: EdgeKind, dstNode: NodeType, srcNode: NodeType): Unit
 }

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/cfg/AstToCfgConverter.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/cfg/AstToCfgConverter.scala
@@ -12,8 +12,7 @@ import io.shiftleft.fuzzyc2cpg.ast.statements.blockstarters._
 import io.shiftleft.fuzzyc2cpg.ast.statements.jump._
 import io.shiftleft.fuzzyc2cpg.ast.walking.ASTNodeVisitor
 import org.slf4j.LoggerFactory
-
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 object AstToCfgConverter {
   private val logger = LoggerFactory.getLogger(getClass)
@@ -31,10 +30,6 @@ class AstToCfgConverter[NodeType](entryNode: NodeType, exitNode: NodeType, adapt
         case FringeElement(node, _) =>
           FringeElement(node, cfgEdgeType)
       }
-    }
-
-    def empty(): List[FringeElement] = {
-      List()
     }
 
     def add(node: NodeType, cfgEdgeType: CfgEdgeType): List[FringeElement] = {
@@ -60,11 +55,11 @@ class AstToCfgConverter[NodeType](entryNode: NodeType, exitNode: NodeType, adapt
       case FringeElement(srcNode, cfgEdgeType) =>
         adapter.newCfgEdge(dstNode, srcNode, cfgEdgeType)
     }
-    fringe = fringe.empty().add(dstNode, AlwaysEdge)
+    fringe = Nil.add(dstNode, AlwaysEdge)
 
     if (markerStack.nonEmpty) {
       // Up until the first none None stack element we replace the Nones with Some(dstNode)
-      val leadingNoneLength = markerStack.prefixLength(_.isEmpty)
+      val leadingNoneLength = markerStack.segmentLength(_.isEmpty, 0)
       markerStack = List.fill(leadingNoneLength)(Some(dstNode)) ++ markerStack
         .drop(leadingNoneLength)
     }
@@ -172,7 +167,7 @@ class AstToCfgConverter[NodeType](entryNode: NodeType, exitNode: NodeType, adapt
     // But if the parser missed a loop or switch statement, breakStack
     // might by empty.
     if (breakStack.numberOfLayers > 0) {
-      fringe = fringe.empty()
+      fringe = Nil
       breakStack.store(mappedBreak)
     }
   }
@@ -232,7 +227,7 @@ class AstToCfgConverter[NodeType](entryNode: NodeType, exitNode: NodeType, adapt
     // But if the parser missed a loop statement, continueStack
     // might by empty.
     if (continueStack.numberOfLayers > 0) {
-      fringe = fringe.empty()
+      fringe = Nil
       continueStack.store(mappedContinue)
     }
   }
@@ -313,8 +308,7 @@ class AstToCfgConverter[NodeType](entryNode: NodeType, exitNode: NodeType, adapt
           val storedFringe = fringe
           fringe = fringe.setCfgEdgeType(TrueEdge)
           storedFringe
-        case None =>
-          fringe.empty()
+        case None => Nil
       }
 
     forStatement.getStatement.accept(this)
@@ -341,7 +335,7 @@ class AstToCfgConverter[NodeType](entryNode: NodeType, exitNode: NodeType, adapt
   override def visit(gotoStatement: GotoStatement): Unit = {
     val mappedGoto = adapter.mapNode(gotoStatement)
     extendCfg(mappedGoto)
-    fringe = fringe.empty()
+    fringe = Nil
     gotos = (mappedGoto, gotoStatement.getTargetName) :: gotos
   }
 
@@ -414,7 +408,7 @@ class AstToCfgConverter[NodeType](entryNode: NodeType, exitNode: NodeType, adapt
     Option(returnStatement.getReturnExpression).foreach(_.accept(this))
     val mappedReturnStatement = adapter.mapNode(returnStatement)
     extendCfg(mappedReturnStatement)
-    fringe = fringe.empty()
+    fringe = Nil
     returns = mappedReturnStatement :: returns
   }
 
@@ -442,7 +436,7 @@ class AstToCfgConverter[NodeType](entryNode: NodeType, exitNode: NodeType, adapt
   override def visit(switchStatement: SwitchStatement): Unit = {
     switchStatement.getCondition.accept(this)
     val conditionFringe = fringe.setCfgEdgeType(CaseEdge)
-    fringe = fringe.empty()
+    fringe = Nil
 
     // We can only push the break and case stacks after we processed the condition
     // in order to allow for nested switches with no nodes CFG nodes in between

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/cfg/CfgAdapter.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/cfg/CfgAdapter.scala
@@ -10,5 +10,5 @@ object CaseEdge extends CfgEdgeType
 
 trait CfgAdapter[NodeType] {
   def mapNode(astNode: AstNode): NodeType
-  def newCfgEdge(dstNode: NodeType, srcNode: NodeType, cfgEdgeType: CfgEdgeType)
+  def newCfgEdge(dstNode: NodeType, srcNode: NodeType, cfgEdgeType: CfgEdgeType): Unit
 }


### PR DESCRIPTION
Unfortunately we have a cyclic dependency with codepropertygraph, but
since it's only a test dependency I took the shortcut of publishing a
2.13 release for codepropertygraph which we use here. Once fuzzyc2cpg
is published for scala 2.13, we can release a normal cpg version which
we can depend on here.
Long term we should resolve the cyclic dependency.