### PR TITLE
Revert "Merge pull request #94 from ShiftLeftSecurity/michael/scala-2…

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,21 +1,20 @@
 name := "fuzzyc2cpg"
 organization := "io.shiftleft"
-scalaVersion := "2.13.0"
+scalaVersion := "2.12.7"
 
-val cpgVersion = "0.9.331a"
+val cpgVersion = "0.9.331"
 
 libraryDependencies ++= Seq(
-  "io.shiftleft" %% "codepropertygraph" % cpgVersion,
-  "io.shiftleft" %% "codepropertygraph-protos" % cpgVersion,
-  "com.github.scopt" %% "scopt" % "3.7.1",
+  "com.github.scopt"   %% "scopt"          % "3.7.0",
   "org.antlr" % "antlr4-runtime" % "4.7.2",
+  "io.shiftleft" % "codepropertygraph" % cpgVersion,
+  "io.shiftleft" % "codepropertygraph-protos" % cpgVersion,
   "org.slf4j" % "slf4j-simple" % "1.7.25" % Runtime,
   "commons-cli" % "commons-cli" % "1.4",
-  "com.github.pathikrit" %% "better-files"  % "3.8.0",
-  "org.scala-lang.modules" %% "scala-parallel-collections" % "0.2.0",
+  "com.github.pathikrit" %% "better-files"  % "3.1.0",
   "com.novocode" % "junit-interface" % "0.11" % Test,
   "junit" % "junit" % "4.12" % Test,
-  "org.scalatest" %% "scalatest" % "3.0.8" % Test,
+  "org.scalatest" %% "scalatest" % "3.0.3" % Test,
 )
 
 // uncomment if you want to use a cpg version that has *just* been released

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=1.2.8
+sbt.version=1.2.6
 

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
@@ -13,7 +13,6 @@ import org.slf4j.LoggerFactory
 import io.shiftleft.fuzzyc2cpg.Utils._
 import io.shiftleft.fuzzyc2cpg.output.CpgOutputModuleFactory
 import io.shiftleft.fuzzyc2cpg.parser.modules.AntlrCModuleParserDriver
-import scala.collection.parallel.CollectionConverters._
 
 class FuzzyC2Cpg(outputModuleFactory: CpgOutputModuleFactory) {
 

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgConverter.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgConverter.scala
@@ -18,7 +18,8 @@ import io.shiftleft.fuzzyc2cpg.astnew.NodeProperty.NodeProperty
 import io.shiftleft.fuzzyc2cpg.scope.Scope
 import io.shiftleft.proto.cpg.Cpg.DispatchTypes
 import org.slf4j.LoggerFactory
-import scala.jdk.CollectionConverters._
+
+import scala.collection.JavaConverters._
 
 object AstToCpgConverter {
   private val logger = LoggerFactory.getLogger(getClass)

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/CpgAdapter.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/CpgAdapter.scala
@@ -27,11 +27,11 @@ trait CpgAdapter[NodeBuilderType, NodeType] {
 
   def createNode(nodeBuilder: NodeBuilderType): NodeType
 
-  def addProperty(nodeBuilder: NodeBuilderType, property: NodeProperty, value: String): Unit
+  def addProperty(nodeBuilder: NodeBuilderType, property: NodeProperty, value: String)
 
-  def addProperty(nodeBuilder: NodeBuilderType, property: NodeProperty, value: Int): Unit
+  def addProperty(nodeBuilder: NodeBuilderType, property: NodeProperty, value: Int)
 
-  def addProperty(nodeBuilder: NodeBuilderType, property: NodeProperty, value: Boolean): Unit
+  def addProperty(nodeBuilder: NodeBuilderType, property: NodeProperty, value: Boolean)
 
-  def addEdge(edgeKind: EdgeKind, dstNode: NodeType, srcNode: NodeType): Unit
+  def addEdge(edgeKind: EdgeKind, dstNode: NodeType, srcNode: NodeType)
 }

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/cfg/CfgAdapter.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/cfg/CfgAdapter.scala
@@ -10,5 +10,5 @@ object CaseEdge extends CfgEdgeType
 
 trait CfgAdapter[NodeType] {
   def mapNode(astNode: AstNode): NodeType
-  def newCfgEdge(dstNode: NodeType, srcNode: NodeType, cfgEdgeType: CfgEdgeType): Unit
+  def newCfgEdge(dstNode: NodeType, srcNode: NodeType, cfgEdgeType: CfgEdgeType)
 }


### PR DESCRIPTION
….13.0"

I am reverting this until we've decided whether or not to switch to Scala 2.13 at this time. The problem is that we currently can't pull up the `fuzzyc2cpg` version in `joern` unless I do this revert.