### PR TITLE
Pick up function declarations (as opposed to definitions)

### DIFF
--- a/src/main/antlr4/io/shiftleft/fuzzyc2cpg/Module.g4
+++ b/src/main/antlr4/io/shiftleft/fuzzyc2cpg/Module.g4
@@ -18,12 +18,13 @@ import ModuleLex, Common;
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-code : (function_def | simple_decl | using_directive | water)*;
+code : (function_decl | function_def | simple_decl | using_directive | water)*;
 
 using_directive: USING NAMESPACE identifier ';';
 
-function_def : template_decl_start? return_type? function_name
-            function_param_list ctor_list? compound_statement;
+function_decl : 'extern'? template_decl_start? return_type? function_name function_param_list ctor_list? ';';
+
+function_def : template_decl_start? return_type? function_name function_param_list ctor_list? compound_statement;
 
 return_type : (function_decl_specifiers* type_name) ptr_operator*;
 

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/parser/modules/CModuleParserTreeListener.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/parser/modules/CModuleParserTreeListener.java
@@ -39,6 +39,22 @@ public class CModuleParserTreeListener extends ModuleBaseListener {
     p.notifyObserversOfUnitEnd(ctx);
   }
 
+  @Override
+  public void enterFunction_decl(ModuleParser.Function_declContext ctx) {
+    FunctionDefBuilder builder = new FunctionDefBuilder();
+    builder.createNew(ctx);
+    p.builderStack.push(builder);
+
+    CompoundStatement functionContent = new CompoundStatement();
+    builder.setContent(functionContent);
+  }
+
+  @Override
+  public void exitFunction_decl(ModuleParser.Function_declContext ctx) {
+    FunctionDefBuilder builder = (FunctionDefBuilder) p.builderStack.pop();
+    p.notifyObserversOfItem(builder.getItem());
+  }
+
   // /////////////////////////////////////////////////////////////
   // This is where the ModuleParser invokes the FunctionParser
   // /////////////////////////////////////////////////////////////

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/AstVisitor.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/AstVisitor.scala
@@ -25,9 +25,9 @@ class AstVisitor(outputModuleFactory: CpgOutputModuleFactory, structureCpg: CpgS
     * */
   override def visit(functionDef: FunctionDef): Unit = {
     val outputModule = outputModuleFactory.create()
-    outputModule.setOutputIdentifier(
-      s"${fileNameOption.get}${functionDef.getName}" +
-        s"${functionDef.getLocation.startLine}${functionDef.getLocation.endLine}")
+    val outputIdentifier = s"${fileNameOption.get}${functionDef.getName}" +
+      s"${functionDef.getLocation.startLine}${functionDef.getLocation.endLine}"
+    outputModule.setOutputIdentifier(outputIdentifier)
 
     val bodyCpg = CpgStruct.newBuilder()
     val cpgAdapter = new ProtoCpgAdapter(bodyCpg)
@@ -42,7 +42,17 @@ class AstVisitor(outputModuleFactory: CpgOutputModuleFactory, structureCpg: CpgS
                                                   graphAdapter)
     astToCfgConverter.convert(functionDef)
 
-    outputModule.persistCpg(bodyCpg)
+    // If this is an empty method, do not persist it yet, just store it
+    if (functionDef.getContent.getStatements.size() == 0) {
+      FuzzyC2CpgCache.emptyFunctions.put(functionDef.getFunctionSignature, (outputIdentifier, bodyCpg))
+    } else {
+      // We've just encountered a non-empty function, so, if a function
+      // with the same signature exists in `emptyFunctions`, remove it
+      if (FuzzyC2CpgCache.emptyFunctions.contains(functionDef.getFunctionSignature)) {
+        FuzzyC2CpgCache.emptyFunctions.remove(functionDef.getFunctionSignature)
+      }
+      outputModule.persistCpg(bodyCpg)
+    }
   }
 
   /**

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/AstVisitor.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/AstVisitor.scala
@@ -42,22 +42,8 @@ class AstVisitor(outputModuleFactory: CpgOutputModuleFactory, structureCpg: CpgS
                                                   graphAdapter)
     astToCfgConverter.convert(functionDef)
 
-    val emptyFunctions = FuzzyC2CpgCache.emptyFunctions
-    var persistCpg: Boolean = false;
-    emptyFunctions.synchronized {
-      // If this is an empty method, do not persist it yet, just store it
-      if (functionDef.getContent.getStatements.size() == 0) {
-        emptyFunctions.put(functionDef.getFunctionSignature, (outputIdentifier, bodyCpg))
-      } else {
-        // We've just encountered a non-empty function, so, if a function
-        // with the same signature exists in `emptyFunctions`, remove it
-        if (emptyFunctions.contains(functionDef.getFunctionSignature)) {
-          emptyFunctions.remove(functionDef.getFunctionSignature)
-        }
-        persistCpg = true;
-      }
-    }
-    if (persistCpg) {
+    val persist = FuzzyC2CpgCache.registerEmptyFunctionOrRemove(functionDef, outputIdentifier, bodyCpg)
+    if (persist) {
       outputModule.persistCpg(bodyCpg)
     }
   }

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
@@ -133,10 +133,11 @@ object FuzzyC2CpgCache {
   def registerEmptyFunctionOrRemove(functionDef: FunctionDef, outputIdentifier: String, bodyCpg: CpgStruct.Builder) : Boolean = {
     emptyFunctions.synchronized {
       val signature = functionDef.getFunctionSignature
-
       // If this is an empty method, do not persist it yet, just store it
-      if (functionDef.getContent.getStatements.size() == 0 && !emptyFunctions.contains(signature)) {
-        emptyFunctions.put(signature, Some(outputIdentifier, bodyCpg))
+      if (functionDef.getContent.getStatements.size() == 0) {
+        if (!emptyFunctions.contains(signature)) {
+          emptyFunctions.put(signature, Some(outputIdentifier, bodyCpg))
+        }
         false
       } else {
         // We've just encountered a non-empty function, so, put a 'None'

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
@@ -149,11 +149,15 @@ object FuzzyC2CpgCache {
   }
 
   def sortedKeySet : List[String] = {
-    FuzzyC2CpgCache.emptyFunctions.keySet.toList.sorted
+    emptyFunctions.synchronized {
+      FuzzyC2CpgCache.emptyFunctions.keySet.toList.sorted
+    }
   }
 
   def get(signature : String) : Option[(String, CpgStruct.Builder)] = {
-    FuzzyC2CpgCache.emptyFunctions(signature)
+    emptyFunctions.synchronized {
+      FuzzyC2CpgCache.emptyFunctions(signature)
+    }
   }
 
 }

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
@@ -38,6 +38,7 @@ class FuzzyC2Cpg(outputModuleFactory: CpgOutputModuleFactory) {
   }
 
   def addEmptyFunctions = {
+    // No locking is required here as we are past concurrent processing
     FuzzyC2CpgCache.emptyFunctions.keySet.toList.sorted.foreach{ signature =>
       val (outputIdentifier, bodyCpg) = FuzzyC2CpgCache.emptyFunctions(signature)
       val outputModule = outputModuleFactory.create()

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgConverter.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgConverter.scala
@@ -159,7 +159,6 @@ class AstToCpgConverter[NodeBuilderType, NodeType](containingFileName: String,
     methodReturnNode = Some(cpgMethodReturn)
 
     addAstChild(cpgMethodReturn)
-
     astFunction.getContent.accept(this)
 
     scope.popScope()


### PR DESCRIPTION
Before this PR, we were just ignoring function declarations, that is, function signatures with missing function bodies. With this PR, we treat these declarations as empty functions, however, we only write them out if there is no function with the same signature that is non-empty.
I will test this with a few more code bases before merging.