### PR TITLE
alternative way to create zip file URI which doesn't fail on windows

### DIFF
--- a/src/main/java/io/shiftleft/fuzzyc2cpg/output/protobuf/ThreadedZipper.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/output/protobuf/ThreadedZipper.java
@@ -57,8 +57,8 @@ class ThreadedZipper extends Thread {
       Path path = Paths.get(this.outputFile);
       URI zipUri;
       try {
-        zipUri = new URI("jar:file", null, path.toAbsolutePath().toString(), null);
-      } catch (URISyntaxException exception) {
+        zipUri = URI.create("jar:" + path.toAbsolutePath().toString());
+      } catch (Exception exception) {
         pool.shutdownNow();
         logger.error(
             "Failed to create URI using path " + path.toAbsolutePath().toString(), exception);


### PR DESCRIPTION
windows errors with an
`java.net.URISyntaxException: relative path in absolute uri`
for the previous way to create a URI. The new one seems to work.