### PR TITLE
Check scalafmt on builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ stages:
 jobs:
   include:
   - stage: test
-    script: sbt +test scalafmtCheck
+    script: sbt scalafmtCheck +test
   - stage: release
     script: sbt ci-release-sonatype
 before_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ stages:
 jobs:
   include:
   - stage: test
-    script: sbt +test
+    script: sbt +test scalafmtCheck
   - stage: release
     script: sbt ci-release-sonatype
 before_cache:


### PR DESCRIPTION
This is one of the few repos left where, on build, we do not check whether code is correctly formatted. This PR changes this.