### PR TITLE
Revert "Merge pull request #99 from ShiftLeftSecurity/michael/ziparch…

### DIFF
--- a/src/main/java/io/shiftleft/fuzzyc2cpg/output/protobuf/ThreadedZipper.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/output/protobuf/ThreadedZipper.java
@@ -57,8 +57,8 @@ class ThreadedZipper extends Thread {
       Path path = Paths.get(this.outputFile);
       URI zipUri;
       try {
-        zipUri = URI.create("jar:" + path.toAbsolutePath().toString());
-      } catch (Exception exception) {
+        zipUri = new URI("jar:file", null, path.toAbsolutePath().toString(), null);
+      } catch (URISyntaxException exception) {
         pool.shutdownNow();
         logger.error(
             "Failed to create URI using path " + path.toAbsolutePath().toString(), exception);


### PR DESCRIPTION
…ive-windowscompat"

This reverts commit 68c146620e304671362439cf83b112a8a309f363, reversing
changes made to 9782b1a08e56b154f0d757c6985b55a48f459e6f.

I am reverting this because it leads to crashes on Linux, triggerable via `./joern-parse $src_dir`.