### PR TITLE
upgrade sbt and release plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
-dist: bionic
-jdk: openjdk10
+dist: xenial
+jdk: openjdk8
 if: tag IS blank
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,36 @@
 language: scala
-jdk: openjdk8
+dist: bionic
+jdk: openjdk10
+if: tag IS blank
+
 branches:
   only:
   - master
+
 before_install:
-- openssl aes-256-cbc -K $encrypted_b3f7bd94ef38_key -iv $encrypted_b3f7bd94ef38_iv
-  -in private-key.pem.enc -out private-key.pem -d
 - git fetch --tags
-install:
-- gpg --import private-key.pem
-- gpg --list-keys
+- if [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_EVENT_TYPE" == "push" ]]; then
+    openssl aes-256-cbc -K $encrypted_b3f7bd94ef38_key -iv $encrypted_b3f7bd94ef38_iv -in private-key.pem.enc -out private-key.pem -d;
+    gpg --import --batch private-key.pem;
+  fi
+
 stages:
 - name: test
 - name: release
   if: branch = master AND type = push
+
 jobs:
   include:
   - stage: test
     script: sbt scalafmtCheck +test
   - stage: release
     script: sbt ci-release-sonatype
+
 before_cache:
-- du -h -d 1 $HOME/.ivy2/cache
-- du -h -d 2 $HOME/.sbt/
 - find $HOME/.sbt -name "*.lock" -type f -delete
 - find $HOME/.ivy2/cache -name "ivydata-*.properties" -type f -delete
 - rm -rf $HOME/.ivy2/local
+
 cache:
   directories:
   - "$HOME/.sbt/1.0/dependency"

--- a/build.sbt
+++ b/build.sbt
@@ -71,4 +71,4 @@ developers := List(
   )
 )
 publishTo := sonatypePublishToBundle.value
-Global/useGpgPinentry := true
+Global / useGpg := false

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "fuzzyc2cpg"
 organization := "io.shiftleft"
-scalaVersion := "2.12.7"
+scalaVersion := "2.12.10"
 
 val cpgVersion = "0.10.3"
 
@@ -70,4 +70,5 @@ developers := List(
     url("https://github.com/julianthome")
   )
 )
-publishTo := sonatypePublishTo.value
+publishTo := sonatypePublishToBundle.value
+Global/useGpgPinentry := true

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=1.2.6
+sbt.version=1.3.0
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,12 +1,11 @@
 dependencyOverrides += "com.puppycrawl.tools" % "checkstyle" % "7.3"
 addSbtPlugin("com.etsy" % "sbt-checkstyle-plugin" % "3.1.1")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.6")
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.1")
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.5")
 addSbtPlugin("com.simplytyped" % "sbt-antlr4" % "0.8.1")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.8.0")
 addSbtPlugin("com.github.sbt" % "sbt-findbugs" % "2.0.0")
-addSbtPlugin("io.shiftleft" % "sbt-ci-release-early"  % "1.0.18")
+addSbtPlugin("io.shiftleft" % "sbt-ci-release-early"  % "1.1.8")
 addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1")
 
 /* TODO upgrade sbt-git to 1.0.1 once that has been released including: https://github.com/sbt/sbt-git/pull/162


### PR DESCRIPTION
Latest release plugin supports sonatype bundle upload which is much faster and should result in less timeouts. Also uses the latest sbt-pgp release which uses the command line `gpg` signer.