### PR TITLE
Function declaration handling

### DIFF
--- a/src/main/antlr4/io/shiftleft/fuzzyc2cpg/Module.g4
+++ b/src/main/antlr4/io/shiftleft/fuzzyc2cpg/Module.g4
@@ -18,12 +18,13 @@ import ModuleLex, Common;
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-code : (function_def | simple_decl | using_directive | water)*;
+code : (function_decl | function_def | simple_decl | using_directive | water)*;
 
 using_directive: USING NAMESPACE identifier ';';
 
-function_def : template_decl_start? return_type? function_name
-            function_param_list ctor_list? compound_statement;
+function_decl : 'extern'? template_decl_start? return_type? function_name function_param_list ctor_list? ';';
+
+function_def : template_decl_start? return_type? function_name function_param_list ctor_list? compound_statement;
 
 return_type : (function_decl_specifiers* type_name) ptr_operator*;
 

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/ast/langc/functiondef/FunctionDef.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/ast/langc/functiondef/FunctionDef.java
@@ -10,6 +10,7 @@ import io.shiftleft.fuzzyc2cpg.ast.walking.ASTNodeVisitor;
 public class FunctionDef extends FunctionDefBase {
 
   private Identifier identifier = null;
+  private boolean isOnlyDeclaration = false;
 
   public Identifier getIdentifier() {
     return this.identifier;
@@ -53,4 +54,13 @@ public class FunctionDef extends FunctionDefBase {
   public void accept(ASTNodeVisitor visitor) {
     visitor.visit(this);
   }
+
+  public void setIsOnlyDeclaration(boolean isOnlyDeclaration) {
+    this.isOnlyDeclaration = isOnlyDeclaration;
+  }
+
+  public boolean isOnlyDeclaration() {
+    return this.isOnlyDeclaration;
+  }
+
 }

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/parser/modules/CModuleParserTreeListener.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/parser/modules/CModuleParserTreeListener.java
@@ -43,10 +43,9 @@ public class CModuleParserTreeListener extends ModuleBaseListener {
   public void enterFunction_decl(ModuleParser.Function_declContext ctx) {
     FunctionDefBuilder builder = new FunctionDefBuilder();
     builder.createNew(ctx);
+    builder.setIsOnlyDeclaration(true);
+    builder.setContent(new CompoundStatement());
     p.builderStack.push(builder);
-
-    CompoundStatement functionContent = new CompoundStatement();
-    builder.setContent(functionContent);
   }
 
   @Override

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/parser/modules/CModuleParserTreeListener.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/parser/modules/CModuleParserTreeListener.java
@@ -39,6 +39,22 @@ public class CModuleParserTreeListener extends ModuleBaseListener {
     p.notifyObserversOfUnitEnd(ctx);
   }
 
+  @Override
+  public void enterFunction_decl(ModuleParser.Function_declContext ctx) {
+    FunctionDefBuilder builder = new FunctionDefBuilder();
+    builder.createNew(ctx);
+    p.builderStack.push(builder);
+
+    CompoundStatement functionContent = new CompoundStatement();
+    builder.setContent(functionContent);
+  }
+
+  @Override
+  public void exitFunction_decl(ModuleParser.Function_declContext ctx) {
+    FunctionDefBuilder builder = (FunctionDefBuilder) p.builderStack.pop();
+    p.notifyObserversOfItem(builder.getItem());
+  }
+
   // /////////////////////////////////////////////////////////////
   // This is where the ModuleParser invokes the FunctionParser
   // /////////////////////////////////////////////////////////////

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/parser/modules/builder/FunctionDefBuilder.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/parser/modules/builder/FunctionDefBuilder.java
@@ -59,4 +59,8 @@ public class FunctionDefBuilder extends AstNodeBuilder {
     thisItem.addChild(functionContent);
   }
 
+  public void setIsOnlyDeclaration(boolean isOnlyDeclaration) {
+    thisItem.setIsOnlyDeclaration(isOnlyDeclaration);
+  }
+
 }

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/AstVisitor.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/AstVisitor.scala
@@ -42,7 +42,7 @@ class AstVisitor(outputModuleFactory: CpgOutputModuleFactory, structureCpg: CpgS
                                                   graphAdapter)
     astToCfgConverter.convert(functionDef)
 
-    if(functionDef.isOnlyDeclaration) {
+    if (functionDef.isOnlyDeclaration) {
       FuzzyC2CpgCache.add(functionDef.getFunctionSignature, outputIdentifier, bodyCpg)
     } else {
       FuzzyC2CpgCache.remove(functionDef.getFunctionSignature)

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/AstVisitor.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/AstVisitor.scala
@@ -43,6 +43,10 @@ class AstVisitor(outputModuleFactory: CpgOutputModuleFactory, structureCpg: CpgS
     astToCfgConverter.convert(functionDef)
 
     if (functionDef.isOnlyDeclaration) {
+      // Do not persist the declaration. It may be that we encounter a
+      // corresponding definition, in which case the declaration will be
+      // removed again and is never persisted. Persisting of declarations
+      // happens after concurrent processing of compilation units.
       FuzzyC2CpgCache.add(functionDef.getFunctionSignature, outputIdentifier, bodyCpg)
     } else {
       FuzzyC2CpgCache.remove(functionDef.getFunctionSignature)

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/AstVisitor.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/AstVisitor.scala
@@ -25,9 +25,9 @@ class AstVisitor(outputModuleFactory: CpgOutputModuleFactory, structureCpg: CpgS
     * */
   override def visit(functionDef: FunctionDef): Unit = {
     val outputModule = outputModuleFactory.create()
-    outputModule.setOutputIdentifier(
-      s"${fileNameOption.get}${functionDef.getName}" +
-        s"${functionDef.getLocation.startLine}${functionDef.getLocation.endLine}")
+    val outputIdentifier = s"${fileNameOption.get}${functionDef.getName}" +
+      s"${functionDef.getLocation.startLine}${functionDef.getLocation.endLine}"
+    outputModule.setOutputIdentifier(outputIdentifier)
 
     val bodyCpg = CpgStruct.newBuilder()
     val cpgAdapter = new ProtoCpgAdapter(bodyCpg)
@@ -42,7 +42,10 @@ class AstVisitor(outputModuleFactory: CpgOutputModuleFactory, structureCpg: CpgS
                                                   graphAdapter)
     astToCfgConverter.convert(functionDef)
 
-    outputModule.persistCpg(bodyCpg)
+    val persist = FuzzyC2CpgCache.registerEmptyFunctionOrRemove(functionDef, outputIdentifier, bodyCpg)
+    if (persist) {
+      outputModule.persistCpg(bodyCpg)
+    }
   }
 
   /**

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/AstVisitor.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/AstVisitor.scala
@@ -42,8 +42,10 @@ class AstVisitor(outputModuleFactory: CpgOutputModuleFactory, structureCpg: CpgS
                                                   graphAdapter)
     astToCfgConverter.convert(functionDef)
 
-    val persist = FuzzyC2CpgCache.registerEmptyFunctionOrRemove(functionDef, outputIdentifier, bodyCpg)
-    if (persist) {
+    if(functionDef.isOnlyDeclaration) {
+      FuzzyC2CpgCache.add(functionDef.getFunctionSignature, outputIdentifier, bodyCpg)
+    } else {
+      FuzzyC2CpgCache.remove(functionDef.getFunctionSignature)
       outputModule.persistCpg(bodyCpg)
     }
   }

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
@@ -139,7 +139,7 @@ object FuzzyC2CpgCache {
       if (functionDeclarations.contains(signature)) {
         val declList = functionDeclarations(signature)
         if (declList.nonEmpty) {
-          functionDeclarations(signature).append((outputIdentifier, cpg))
+          declList.append((outputIdentifier, cpg))
         }
       } else {
         functionDeclarations.put(signature, mutable.ListBuffer((outputIdentifier, cpg)))

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
@@ -37,7 +37,7 @@ class FuzzyC2Cpg(outputModuleFactory: CpgOutputModuleFactory) {
     outputModuleFactory.persist()
   }
 
-  private def addFunctionDeclarations : Unit = {
+  private def addFunctionDeclarations: Unit = {
     FuzzyC2CpgCache.sortedSignatures.foreach { signature =>
       FuzzyC2CpgCache.getDeclarations(signature).foreach {
         case (outputIdentifier, bodyCpg) =>
@@ -134,12 +134,12 @@ object FuzzyC2CpgCache {
     * Unless `remove` has been called for `signature`, add (outputIdentifier, cpg)
     * pair to the list declarations stored for `signature`.
     * */
-  def add(signature : String, outputIdentifier : String, cpg : CpgStruct.Builder): Unit = {
+  def add(signature: String, outputIdentifier: String, cpg: CpgStruct.Builder): Unit = {
     functionDeclarations.synchronized {
       if (functionDeclarations.contains(signature)) {
         val declList = functionDeclarations(signature)
         if (declList.nonEmpty) {
-         functionDeclarations(signature).append((outputIdentifier, cpg))
+          functionDeclarations(signature).append((outputIdentifier, cpg))
         }
       } else {
         functionDeclarations.put(signature, mutable.ListBuffer((outputIdentifier, cpg)))
@@ -153,8 +153,8 @@ object FuzzyC2CpgCache {
     * therefore, no declaration should be written for functions
     * with this signature.
     * */
-  def remove(signature : String) : Unit = {
-    functionDeclarations.synchronized{
+  def remove(signature: String): Unit = {
+    functionDeclarations.synchronized {
       functionDeclarations.put(signature, mutable.ListBuffer())
     }
   }

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgConverter.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgConverter.scala
@@ -159,7 +159,6 @@ class AstToCpgConverter[NodeBuilderType, NodeType](containingFileName: String,
     methodReturnNode = Some(cpgMethodReturn)
 
     addAstChild(cpgMethodReturn)
-
     astFunction.getContent.accept(this)
 
     scope.popScope()


### PR DESCRIPTION
I cleaned up and fixed the function declaration handling. This has now also been tested with `codepropertygraph` and tests are not flaky with it. The core improvement of this PR over the previous is that we now specifically mark function declarations as such, and do nit simple treat them as function definitions with empty bodies. By doing so, we can ensure that function definitions are always written out, and therefore, it cannot happen that we report less information than before the PR. I have also ensured that the number of methods generated is the same over consecutive runs.