### PR TITLE
[#106] Fix parsing of comments within functions.

### DIFF
--- a/src/main/java/io/shiftleft/fuzzyc2cpg/parser/AntlrParserDriver.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/parser/AntlrParserDriver.java
@@ -161,7 +161,7 @@ abstract public class AntlrParserDriver {
     try {
       return CharStreams.fromFileName(filename);
     } catch (IOException exception) {
-      throw new ParserException("");
+      throw new RuntimeException(String.format("Unable to find source file [%s]", filename));
     }
 
   }

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/parser/TokenSubStream.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/parser/TokenSubStream.java
@@ -2,10 +2,11 @@ package io.shiftleft.fuzzyc2cpg.parser;
 
 import java.util.Stack;
 import org.antlr.v4.runtime.BufferedTokenStream;
+import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.TokenSource;
 
-public class TokenSubStream extends BufferedTokenStream {
+public class TokenSubStream extends CommonTokenStream {
 
   protected int stopIndex = -1;
   protected int startIndex = 0;

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/parser/modules/CModuleParserTreeListener.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/parser/modules/CModuleParserTreeListener.java
@@ -1,5 +1,10 @@
 package io.shiftleft.fuzzyc2cpg.parser.modules;
 
+import java.util.Iterator;
+import java.util.List;
+
+import org.antlr.v4.runtime.ParserRuleContext;
+
 import io.shiftleft.fuzzyc2cpg.ModuleBaseListener;
 import io.shiftleft.fuzzyc2cpg.ModuleParser;
 import io.shiftleft.fuzzyc2cpg.ModuleParser.Class_defContext;
@@ -15,9 +20,6 @@ import io.shiftleft.fuzzyc2cpg.parser.ModuleFunctionParserInterface;
 import io.shiftleft.fuzzyc2cpg.parser.modules.builder.FunctionDefBuilder;
 import io.shiftleft.fuzzyc2cpg.parser.shared.builders.ClassDefBuilder;
 import io.shiftleft.fuzzyc2cpg.parser.shared.builders.IdentifierDeclBuilder;
-import java.util.Iterator;
-import java.util.List;
-import org.antlr.v4.runtime.ParserRuleContext;
 
 // Converts Parse Trees to ASTs for Modules
 

--- a/src/test/java/io/shiftleft/fuzzyc2cpg/antlrparsers/functionparser/FunctionCommentTests.java
+++ b/src/test/java/io/shiftleft/fuzzyc2cpg/antlrparsers/functionparser/FunctionCommentTests.java
@@ -1,0 +1,77 @@
+package io.shiftleft.fuzzyc2cpg.antlrparsers.functionparser;
+
+import static org.junit.Assert.assertEquals;
+
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.junit.Test;
+
+import io.shiftleft.fuzzyc2cpg.FunctionParser;
+import io.shiftleft.fuzzyc2cpg.parser.AntlrParserDriver;
+
+public class FunctionCommentTests extends FunctionParserTestBase {
+
+  @Test
+  public void testLineComment() {
+    String input = "// This is a comment!";
+    FunctionParser parser = createHiddenParser(input);
+    assertEquals(parser.getCurrentToken().getText(), "// This is a comment!");
+  }
+
+  @Test
+  public void testLineCommentAfterStatement() {
+    String input = "int x = 5; // This is a comment!";
+    FunctionParser parser = createHiddenParser(input);
+    assertEquals(parser.getCurrentToken().getText(), "// This is a comment!");
+  }
+
+  @Test
+  public void testBlockComment() {
+    String input = "/* This is a block comment! */";
+    FunctionParser parser = createHiddenParser(input);
+    assertEquals(parser.getCurrentToken().getText(), "/* This is a block comment! */");
+  }
+
+  @Test
+  public void testBlockCommentWithinStatement() {
+    String input = "int /* This is a block comment! */ x = 5;";
+    FunctionParser parser = createHiddenParser(input);
+    assertEquals(parser.getCurrentToken().getText(), "/* This is a block comment! */");
+  }
+
+  private void compareParses(String actual, String expected) {
+    AntlrParserDriver functionParser = createFunctionDriver();
+    ParseTree actualTree = functionParser.parseString(actual);
+    ParseTree expectedTree = functionParser.parseString(expected);
+    String actualOutput = actualTree.toStringTree(functionParser.getAntlrParser());
+    String expectedOutput = expectedTree.toStringTree(functionParser.getAntlrParser());
+    assertEquals(actualOutput, expectedOutput);
+  }
+
+  @Test
+  public void testLineCommentDriver() {
+    String inputWithComment = "// This is a comment!";
+    String inputWithoutComment = "";
+    compareParses(inputWithComment, inputWithoutComment);
+  }
+
+  @Test
+  public void testLineCommentAfterStatementDriver() {
+    String inputWithComment = "int x = 5; // This is a comment!";
+    String inputWithoutComment = "int x = 5;";
+    compareParses(inputWithComment, inputWithoutComment);
+  }
+
+  @Test
+  public void testBlockCommentDriver() {
+    String inputWithComment = "/* This is a block comment! */";
+    String inputWithoutComment = "";
+    compareParses(inputWithComment, inputWithoutComment);
+  }
+
+  @Test
+  public void testBlockCommentWithinStatementDriver() {
+    String inputWithComment = "int /* This is a block comment! */ x = 5;";
+    String inputWithoutComment = "int x = 5;";
+    compareParses(inputWithComment, inputWithoutComment);
+  }
+}

--- a/src/test/java/io/shiftleft/fuzzyc2cpg/antlrparsers/functionparser/FunctionParserTestBase.java
+++ b/src/test/java/io/shiftleft/fuzzyc2cpg/antlrparsers/functionparser/FunctionParserTestBase.java
@@ -1,16 +1,26 @@
 package io.shiftleft.fuzzyc2cpg.antlrparsers.functionparser;
 
 
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.Token;
+
+import io.shiftleft.fuzzyc2cpg.FunctionLexer;
+import io.shiftleft.fuzzyc2cpg.FunctionParser;
 import io.shiftleft.fuzzyc2cpg.parser.AntlrParserDriver;
+import io.shiftleft.fuzzyc2cpg.parser.TokenSubStream;
 import io.shiftleft.fuzzyc2cpg.parser.functions.AntlrCFunctionParserDriver;
 
-public class FunctionParserTestBase
-{
-	protected AntlrParserDriver createFunctionDriver()
-	{
-		AntlrCFunctionParserDriver driver = new AntlrCFunctionParserDriver();
-
-		return driver;
+public class FunctionParserTestBase {
+	protected AntlrParserDriver createFunctionDriver() {
+		return new AntlrCFunctionParserDriver();
 	}
 
+	protected FunctionParser createHiddenParser(String input) {
+		CharStream inputStream = CharStreams.fromString(input);
+		FunctionLexer lexer = new FunctionLexer(inputStream);
+		CommonTokenStream cts = new CommonTokenStream(lexer, Token.HIDDEN_CHANNEL);
+		return new FunctionParser(cts);
+	}
 }

--- a/src/test/java/io/shiftleft/fuzzyc2cpg/antlrparsers/moduleparser/ModuleCommentTests.java
+++ b/src/test/java/io/shiftleft/fuzzyc2cpg/antlrparsers/moduleparser/ModuleCommentTests.java
@@ -7,7 +7,7 @@ import org.junit.Test;
 
 import io.shiftleft.fuzzyc2cpg.ModuleParser;
 
-public class CommentTests extends ModuleParserTest {
+public class ModuleCommentTests extends ModuleParserTest {
 
   private void assertTokenEqualsString(Token tok, String expected) {
     assertEquals(expected, tok.getText());


### PR DESCRIPTION
- `TokenSubStream` now subclasses `CommonTokenStream`, which filters out "hidden" tokens, rather than `BufferedTokenStream` which does not.