### PR TITLE
[#60] Enhance support for template parsing.

### DIFF
--- a/src/main/antlr4/io/shiftleft/fuzzyc2cpg/Common.g4
+++ b/src/main/antlr4/io/shiftleft/fuzzyc2cpg/Common.g4
@@ -103,14 +103,17 @@ operator: (('new' | 'delete' ) ('[' ']')?)
 assignment_operator: '=' | '*=' | '/=' | '%=' | '+=' | '-=' | '<<=' | '>>=' | '&=' | '^=' | '|='; 
 equality_operator: ('=='| '!=');
 
-template_decl_start : TEMPLATE '<' template_param_list '>';
+// TODO: Does not support default types (e.g. template<typename N = int>). To achieve extend template_decl_param.
+template_decl: TEMPLATE '<' template_decl_param_list? '>';
+template_decl_param_list: template_template template_name |
+                          template_decl_param |
+                          template_decl_param_list ',' template_decl_param;
+template_template: TEMPLATE '<' (template_decl_keyword ','?)+ '>';
+template_decl_param: template_decl_keyword template_name?;
+template_decl_keyword: 'typename' | 'class';
+template_name: ALPHA_NUMERIC+ ELLIPSIS? ;
 
-
-// template water
-template_param_list : (('<' template_param_list '>') |
-                       ('(' template_param_list ')') | 
-                       no_angle_brackets_or_brackets)+
-;
+template_args: ('<' template_args '>' | '(' template_args ')' | base_type ELLIPSIS? | ',')+;
 
 // water
 
@@ -137,16 +140,16 @@ number: HEX_LITERAL | DECIMAL_LITERAL | OCTAL_LITERAL;
 ptrs: (CV_QUALIFIER? ptr_operator 'restrict'?)+;
 func_ptrs: ptrs;
 
+class_key: 'struct' | 'class' | 'union' | 'enum';
 
-
-class_def: CLASS_KEY gcc_attribute? class_name? base_classes? OPENING_CURLY {skipToEndOfObject(); } ;
+class_def: template_decl? class_key gcc_attribute? class_name? template_args? base_classes? OPENING_CURLY {skipToEndOfObject(); } ;
 class_name: identifier;
 base_classes: ':' base_class (',' base_class)*;
 base_class: VIRTUAL? access_specifier? identifier;
 
 
-type_name : (CV_QUALIFIER* (CLASS_KEY | UNSIGNED | SIGNED)?
-            base_type ('<' template_param_list '>')? ('::' base_type ('<' template_param_list '>')? )*) CV_QUALIFIER?
+type_name : (CV_QUALIFIER* (class_key | UNSIGNED | SIGNED)?
+            base_type ('<' template_args '>')? ('::' base_type ('<' template_args '>')? )*) CV_QUALIFIER?
           | UNSIGNED
           | SIGNED
           ;

--- a/src/main/antlr4/io/shiftleft/fuzzyc2cpg/Common.g4
+++ b/src/main/antlr4/io/shiftleft/fuzzyc2cpg/Common.g4
@@ -105,7 +105,7 @@ equality_operator: ('=='| '!=');
 
 // TODO: Does not support default types (e.g. template<typename N = int>). To achieve extend template_decl_param.
 template_decl: TEMPLATE '<' template_decl_param_list? '>';
-template_decl_param_list: template_template template_name |
+template_decl_param_list: template_template template_decl_keyword template_name |
                           template_decl_param |
                           template_decl_param_list ',' template_decl_param;
 template_template: TEMPLATE '<' (template_decl_keyword ','?)+ '>';

--- a/src/main/antlr4/io/shiftleft/fuzzyc2cpg/Function.g4
+++ b/src/main/antlr4/io/shiftleft/fuzzyc2cpg/Function.g4
@@ -72,10 +72,10 @@ type_suffix : ('[' conditional_expression? ']') | param_type_list;
 
 // Copied from SimpleDecl.g4
 
-simple_decl : (TYPEDEF? template_decl_start?) var_decl;
+simple_decl : (TYPEDEF?) var_decl;
 
 var_decl : class_def init_declarator_list? #declByClass
-         | type_name init_declarator_list #declByType
+         | template_decl? type_name init_declarator_list #declByType
          ;
 
 init_declarator_list: init_declarator (',' init_declarator)* ';';

--- a/src/main/antlr4/io/shiftleft/fuzzyc2cpg/Module.g4
+++ b/src/main/antlr4/io/shiftleft/fuzzyc2cpg/Module.g4
@@ -22,9 +22,9 @@ code : (function_decl | function_def | simple_decl | using_directive | water)*;
 
 using_directive: USING NAMESPACE identifier ';';
 
-function_decl : 'extern'? template_decl_start? return_type? function_name function_param_list ctor_list? ';';
+function_decl: ('extern' | template_decl)? return_type? function_name function_param_list ctor_list? ';';
 
-function_def : template_decl_start? return_type? function_name function_param_list ctor_list? compound_statement;
+function_def: template_decl? return_type? function_name function_param_list ctor_list? compound_statement;
 
 return_type : (function_decl_specifiers* type_name) ptr_operator*;
 
@@ -68,12 +68,12 @@ assign_expr_w__l2: assign_water_l2* (('{' assign_expr_w__l2 '}' | '(' assign_exp
 
 constant_expr_w_: no_squares* ('[' constant_expr_w_ ']' no_squares*)*;
 
-simple_decl : (storage_class_specifier* template_decl_start?) var_decl;
+simple_decl : storage_class_specifier* var_decl;
 
 storage_class_specifier: (EXTERN | TYPEDEF);
 
 var_decl : class_def init_declarator_list? #declByClass
-         | type_name init_declarator_list #declByType
+         | template_decl? type_name init_declarator_list #declByType
          ;
 
 init_declarator_list: init_declarator (',' init_declarator)* ';';

--- a/src/main/antlr4/io/shiftleft/fuzzyc2cpg/ModuleLex.g4
+++ b/src/main/antlr4/io/shiftleft/fuzzyc2cpg/ModuleLex.g4
@@ -32,8 +32,6 @@ NEW: 'new';
 
 GCC_ATTRIBUTE : '__attribute__';
 
-CLASS_KEY: ('struct' | 'class' | 'union' | 'enum');
-
 ALPHA_NUMERIC: [a-zA-Z_~][a-zA-Z0-9_]*;
 
 OPENING_CURLY: '{';

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/ast/declarations/ClassDefStatement.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/ast/declarations/ClassDefStatement.java
@@ -3,6 +3,7 @@ package io.shiftleft.fuzzyc2cpg.ast.declarations;
 import io.shiftleft.fuzzyc2cpg.ast.AstNode;
 import io.shiftleft.fuzzyc2cpg.ast.DummyIdentifierNode;
 import io.shiftleft.fuzzyc2cpg.ast.expressions.Identifier;
+import io.shiftleft.fuzzyc2cpg.ast.functionDef.TemplateParameterList;
 import io.shiftleft.fuzzyc2cpg.ast.logical.statements.CompoundStatement;
 import io.shiftleft.fuzzyc2cpg.ast.logical.statements.Statement;
 import io.shiftleft.fuzzyc2cpg.ast.walking.ASTNodeVisitor;
@@ -11,10 +12,13 @@ public class ClassDefStatement extends Statement {
 
   public Identifier identifier = new DummyIdentifierNode();
   public CompoundStatement content = new CompoundStatement();
+  protected TemplateParameterList templateParameterList;
 
   public void addChild(AstNode expression) {
     if (expression instanceof Identifier) {
       setIdentifier((Identifier) expression);
+    } else if (expression instanceof TemplateParameterList) {
+      setTemplateParameterList((TemplateParameterList) expression);
     } else {
       super.addChild(expression);
     }
@@ -27,6 +31,15 @@ public class ClassDefStatement extends Statement {
   private void setIdentifier(Identifier identifier) {
     this.identifier = identifier;
     super.addChild(identifier);
+  }
+
+  public TemplateParameterList getTemplateParameterList() {
+    return templateParameterList;
+  }
+
+  private void setTemplateParameterList(TemplateParameterList templateParameterList) {
+    this.templateParameterList = templateParameterList;
+    super.addChild(templateParameterList);
   }
 
   @Override

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/ast/functionDef/FunctionDefBase.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/ast/functionDef/FunctionDefBase.java
@@ -6,9 +6,10 @@ import io.shiftleft.fuzzyc2cpg.ast.walking.ASTNodeVisitor;
 
 public abstract class FunctionDefBase extends AstNode {
 
-  protected ParameterList parameterList = null;
-  protected ReturnType returnType = null;
-  protected CompoundStatement content = null;
+  protected ParameterList parameterList;
+  protected TemplateParameterList templateParameterList;
+  protected ReturnType returnType;
+  protected CompoundStatement content;
 
   public abstract String getName();
 
@@ -29,6 +30,15 @@ public abstract class FunctionDefBase extends AstNode {
   public void setParameterList(ParameterList parameterList) {
     this.parameterList = parameterList;
     super.addChild(parameterList);
+  }
+
+  public TemplateParameterList getTemplateParameterList() {
+    return templateParameterList;
+  }
+
+  public void setTemplateParameterList(TemplateParameterList templateParameterList) {
+    this.templateParameterList = templateParameterList;
+    super.addChild(templateParameterList);
   }
 
   public CompoundStatement getContent() {

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/ast/functionDef/Template.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/ast/functionDef/Template.java
@@ -1,6 +1,7 @@
 package io.shiftleft.fuzzyc2cpg.ast.functionDef;
 
 import io.shiftleft.fuzzyc2cpg.ast.AstNode;
+import io.shiftleft.fuzzyc2cpg.ast.walking.ASTNodeVisitor;
 
 public class Template extends TemplateBase {
   private TemplateTypeName typeName;
@@ -21,5 +22,10 @@ public class Template extends TemplateBase {
     } else {
       super.addChild(node);
     }
+  }
+
+  @Override
+  public void accept(ASTNodeVisitor visitor) {
+    visitor.visit(this);
   }
 }

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/ast/functionDef/Template.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/ast/functionDef/Template.java
@@ -1,0 +1,25 @@
+package io.shiftleft.fuzzyc2cpg.ast.functionDef;
+
+import io.shiftleft.fuzzyc2cpg.ast.AstNode;
+
+public class Template extends TemplateBase {
+  private TemplateTypeName typeName;
+
+  private void setTemplateTypeName(TemplateTypeName typeName) {
+    this.typeName = typeName;
+    super.addChild(typeName);
+  }
+
+  @Override
+  public String getName() {
+    return typeName.getEscapedCodeStr();
+  }
+
+  public void addChild(AstNode node) {
+    if (node instanceof TemplateTypeName) {
+      setTemplateTypeName((TemplateTypeName) node);
+    } else {
+      super.addChild(node);
+    }
+  }
+}

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/ast/functionDef/TemplateBase.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/ast/functionDef/TemplateBase.java
@@ -1,0 +1,13 @@
+package io.shiftleft.fuzzyc2cpg.ast.functionDef;
+
+import io.shiftleft.fuzzyc2cpg.ast.AstNode;
+import io.shiftleft.fuzzyc2cpg.ast.walking.ASTNodeVisitor;
+
+public abstract class TemplateBase extends AstNode {
+  public abstract String getName();
+
+  @Override
+  public void accept(ASTNodeVisitor visitor) {
+    visitor.visit(this);
+  }
+}

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/ast/functionDef/TemplateParameterList.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/ast/functionDef/TemplateParameterList.java
@@ -1,0 +1,44 @@
+package io.shiftleft.fuzzyc2cpg.ast.functionDef;
+
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import io.shiftleft.fuzzyc2cpg.ast.AstNode;
+
+public class TemplateParameterList extends AstNode implements Iterable<TemplateBase>  {
+  private final List<TemplateBase> templates = new LinkedList<>();
+
+  private void addTemplateParameter(TemplateBase template) {
+    this.templates.add(template);
+    super.addChild(template);
+  }
+
+  public int size() {
+    return templates.size();
+  }
+
+  @Override
+  public void addChild(AstNode node) {
+    if (node instanceof TemplateBase) { addTemplateParameter((TemplateBase) node); }
+    else { super.addChild(node); }
+  }
+
+  @Override
+  public String getEscapedCodeStr() {
+    String codeStr = templates
+      .stream()
+      .map(TemplateBase::getEscapedCodeStr)
+      .collect(Collectors.joining(",", "<", ">"));
+
+    setCodeStr(codeStr);
+
+    return codeStr;
+  }
+
+  @Override
+  public Iterator<TemplateBase> iterator() {
+    return templates.iterator();
+  }
+}

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/ast/functionDef/TemplateTypeName.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/ast/functionDef/TemplateTypeName.java
@@ -1,0 +1,12 @@
+package io.shiftleft.fuzzyc2cpg.ast.functionDef;
+
+import io.shiftleft.fuzzyc2cpg.ast.AstNode;
+
+public class TemplateTypeName extends AstNode {
+
+  private final String typeName;
+
+  public TemplateTypeName(String typeName) {
+    this.typeName = typeName;
+  }
+}

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/ast/langc/functiondef/FunctionDef.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/ast/langc/functiondef/FunctionDef.java
@@ -4,6 +4,8 @@ import io.shiftleft.fuzzyc2cpg.ast.AstNode;
 import io.shiftleft.fuzzyc2cpg.ast.expressions.Identifier;
 import io.shiftleft.fuzzyc2cpg.ast.functionDef.FunctionDefBase;
 import io.shiftleft.fuzzyc2cpg.ast.functionDef.ParameterList;
+import io.shiftleft.fuzzyc2cpg.ast.functionDef.Template;
+import io.shiftleft.fuzzyc2cpg.ast.functionDef.TemplateParameterList;
 import io.shiftleft.fuzzyc2cpg.ast.logical.statements.CompoundStatement;
 import io.shiftleft.fuzzyc2cpg.ast.walking.ASTNodeVisitor;
 
@@ -43,6 +45,8 @@ public class FunctionDef extends FunctionDefBase {
       setContent((CompoundStatement) node);
     } else if (node instanceof ParameterList) {
       setParameterList((ParameterList) node);
+    } else if (node instanceof TemplateParameterList) {
+      setTemplateParameterList((TemplateParameterList) node);
     } else if (node instanceof Identifier) {
       setIdentifier((Identifier) node);
     } else {

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/ast/walking/ASTNodeVisitor.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/ast/walking/ASTNodeVisitor.java
@@ -52,10 +52,7 @@ import io.shiftleft.fuzzyc2cpg.ast.expressions.UnaryExpression;
 import io.shiftleft.fuzzyc2cpg.ast.expressions.UnaryOperationExpression;
 import io.shiftleft.fuzzyc2cpg.ast.expressions.UnaryOperator;
 import io.shiftleft.fuzzyc2cpg.ast.expressions.Variable;
-import io.shiftleft.fuzzyc2cpg.ast.functionDef.FunctionDefBase;
-import io.shiftleft.fuzzyc2cpg.ast.functionDef.ParameterBase;
-import io.shiftleft.fuzzyc2cpg.ast.functionDef.ParameterList;
-import io.shiftleft.fuzzyc2cpg.ast.functionDef.ReturnType;
+import io.shiftleft.fuzzyc2cpg.ast.functionDef.*;
 import io.shiftleft.fuzzyc2cpg.ast.langc.expressions.CallExpression;
 import io.shiftleft.fuzzyc2cpg.ast.langc.expressions.SizeofExpression;
 import io.shiftleft.fuzzyc2cpg.ast.langc.functiondef.FunctionDef;
@@ -335,6 +332,22 @@ public interface ASTNodeVisitor {
 
   default void visit(ParameterType parameterType) {
     visit((AstNode)parameterType);
+  }
+
+  default void visit(TemplateBase templateBase) {
+    visit((AstNode) templateBase);
+  }
+
+  default void visit(Template template) {
+    visit((TemplateBase) template);
+  }
+
+  default void visit(TemplateTypeName templateTypeName) {
+    visit((AstNode) templateTypeName);
+  }
+
+  default void visit(TemplateParameterList templateParameterList) {
+    visit((AstNode) templateParameterList);
   }
 
   default void visit(ElseStatement statement) {

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/parser/AstNodeFactory.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/parser/AstNodeFactory.java
@@ -1,23 +1,23 @@
 package io.shiftleft.fuzzyc2cpg.parser;
 
+import org.antlr.v4.runtime.ParserRuleContext;
+
 import io.shiftleft.fuzzyc2cpg.FunctionParser.InitDeclWithAssignContext;
 import io.shiftleft.fuzzyc2cpg.FunctionParser.StatementContext;
 import io.shiftleft.fuzzyc2cpg.ModuleParser.Parameter_declContext;
 import io.shiftleft.fuzzyc2cpg.ModuleParser.Parameter_idContext;
 import io.shiftleft.fuzzyc2cpg.ModuleParser.Parameter_nameContext;
+import io.shiftleft.fuzzyc2cpg.ModuleParser.Template_nameContext;
 import io.shiftleft.fuzzyc2cpg.ast.AstNode;
 import io.shiftleft.fuzzyc2cpg.ast.expressions.AssignmentExpression;
 import io.shiftleft.fuzzyc2cpg.ast.expressions.BinaryExpression;
 import io.shiftleft.fuzzyc2cpg.ast.expressions.Expression;
 import io.shiftleft.fuzzyc2cpg.ast.expressions.Identifier;
+import io.shiftleft.fuzzyc2cpg.ast.functionDef.Template;
+import io.shiftleft.fuzzyc2cpg.ast.functionDef.TemplateTypeName;
 import io.shiftleft.fuzzyc2cpg.ast.langc.functiondef.Parameter;
 import io.shiftleft.fuzzyc2cpg.ast.langc.functiondef.ParameterType;
 import io.shiftleft.fuzzyc2cpg.ast.logical.statements.Statement;
-import org.antlr.v4.runtime.ANTLRInputStream;
-import org.antlr.v4.runtime.CharStream;
-import org.antlr.v4.runtime.CharStreams;
-import org.antlr.v4.runtime.ParserRuleContext;
-import org.antlr.v4.runtime.misc.Interval;
 
 public class AstNodeFactory {
 
@@ -112,4 +112,17 @@ public class AstNodeFactory {
     return parameterId.parameter_name();
   }
 
+  public static Template create(Template_nameContext ctx) {
+
+    Template template = new Template();
+
+    String typeName = ParseTreeUtils.childTokenString(ctx);
+    TemplateTypeName templateType = new TemplateTypeName(typeName);
+
+    initializeFromContext(templateType, ctx);
+    initializeFromContext(template, ctx);
+
+    template.addChild(templateType);
+    return template;
+  }
 }

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/parser/functions/CFunctionParseTreeListener.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/parser/functions/CFunctionParseTreeListener.java
@@ -11,7 +11,7 @@ import io.shiftleft.fuzzyc2cpg.parser.functions.builder.FunctionContentBuilder;
 
 public class CFunctionParseTreeListener extends FunctionBaseListener {
 
-  AntlrParserDriver p;
+  private final AntlrParserDriver p;
 
   public CFunctionParseTreeListener(AntlrParserDriver aP) {
     p = aP;

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/parser/functions/builder/TemplateParameterListBuilder.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/parser/functions/builder/TemplateParameterListBuilder.java
@@ -1,0 +1,28 @@
+package io.shiftleft.fuzzyc2cpg.parser.functions.builder;
+
+import org.antlr.v4.runtime.ParserRuleContext;
+
+import io.shiftleft.fuzzyc2cpg.ModuleParser.Template_nameContext;
+import io.shiftleft.fuzzyc2cpg.ast.AstNodeBuilder;
+import io.shiftleft.fuzzyc2cpg.ast.functionDef.Template;
+import io.shiftleft.fuzzyc2cpg.ast.functionDef.TemplateParameterList;
+import io.shiftleft.fuzzyc2cpg.parser.AstNodeFactory;
+
+public class TemplateParameterListBuilder extends AstNodeBuilder {
+  private final TemplateParameterList templateParameterList = new TemplateParameterList();
+
+  public TemplateParameterListBuilder() {
+    item = templateParameterList;
+  }
+
+  @Override
+  public void createNew(ParserRuleContext ctx) {
+    AstNodeFactory.initializeFromContext(templateParameterList, ctx);
+  }
+
+  public void addTemplateParameter(Template_nameContext ctx) {
+    Template template = AstNodeFactory.create(ctx);
+    templateParameterList.addChild(template);
+  }
+
+}

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/parser/modules/CModuleParserTreeListener.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/parser/modules/CModuleParserTreeListener.java
@@ -20,6 +20,7 @@ import io.shiftleft.fuzzyc2cpg.parser.ModuleFunctionParserInterface;
 import io.shiftleft.fuzzyc2cpg.parser.modules.builder.FunctionDefBuilder;
 import io.shiftleft.fuzzyc2cpg.parser.shared.builders.ClassDefBuilder;
 import io.shiftleft.fuzzyc2cpg.parser.shared.builders.IdentifierDeclBuilder;
+import io.shiftleft.fuzzyc2cpg.parser.shared.builders.TemplateAstBuilder;
 
 // Converts Parse Trees to ASTs for Modules
 
@@ -67,7 +68,6 @@ public class CModuleParserTreeListener extends ModuleBaseListener {
 
   @Override
   public void enterFunction_def(ModuleParser.Function_defContext ctx) {
-
     FunctionDefBuilder builder = new FunctionDefBuilder();
     builder.createNew(ctx);
     p.builderStack.push(builder);
@@ -106,6 +106,19 @@ public class CModuleParserTreeListener extends ModuleBaseListener {
   public void enterParameter_decl(ModuleParser.Parameter_declContext ctx) {
     FunctionDefBuilder builder = (FunctionDefBuilder) p.builderStack.peek();
     builder.addParameter(ctx, p.builderStack);
+  }
+
+  @Override
+  public void enterTemplate_decl(ModuleParser.Template_declContext ctx) {
+    TemplateAstBuilder<?> builder = (TemplateAstBuilder<?>) p.builderStack.peek();
+    builder.setTemplateList(ctx);
+  }
+
+
+  @Override
+  public void enterTemplate_name(ModuleParser.Template_nameContext ctx) {
+    TemplateAstBuilder<?> builder = (TemplateAstBuilder) p.builderStack.peek();
+    builder.addTemplateParameter(ctx);
   }
 
   // DeclByType

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/parser/modules/builder/FunctionDefBuilder.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/parser/modules/builder/FunctionDefBuilder.java
@@ -1,24 +1,23 @@
 package io.shiftleft.fuzzyc2cpg.parser.modules.builder;
 
-import io.shiftleft.fuzzyc2cpg.ModuleParser.Function_nameContext;
-import io.shiftleft.fuzzyc2cpg.ModuleParser.Function_param_listContext;
-import io.shiftleft.fuzzyc2cpg.ModuleParser.Parameter_declContext;
-import io.shiftleft.fuzzyc2cpg.ModuleParser.Return_typeContext;
-import io.shiftleft.fuzzyc2cpg.ast.AstNodeBuilder;
-import io.shiftleft.fuzzyc2cpg.ast.langc.functiondef.FunctionDef;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.Identifier;
-import io.shiftleft.fuzzyc2cpg.ast.functionDef.ReturnType;
-import io.shiftleft.fuzzyc2cpg.ast.logical.statements.CompoundStatement;
-import io.shiftleft.fuzzyc2cpg.parser.AstNodeFactory;
-import io.shiftleft.fuzzyc2cpg.parser.functions.builder.ParameterListBuilder;
-import io.shiftleft.fuzzyc2cpg.parser.ParseTreeUtils;
 import java.util.Stack;
+
 import org.antlr.v4.runtime.ParserRuleContext;
 
-public class FunctionDefBuilder extends AstNodeBuilder {
+import io.shiftleft.fuzzyc2cpg.ModuleParser.*;
+import io.shiftleft.fuzzyc2cpg.ast.AstNodeBuilder;
+import io.shiftleft.fuzzyc2cpg.ast.expressions.Identifier;
+import io.shiftleft.fuzzyc2cpg.ast.functionDef.ReturnType;
+import io.shiftleft.fuzzyc2cpg.ast.langc.functiondef.FunctionDef;
+import io.shiftleft.fuzzyc2cpg.ast.logical.statements.CompoundStatement;
+import io.shiftleft.fuzzyc2cpg.parser.AstNodeFactory;
+import io.shiftleft.fuzzyc2cpg.parser.ParseTreeUtils;
+import io.shiftleft.fuzzyc2cpg.parser.functions.builder.ParameterListBuilder;
+import io.shiftleft.fuzzyc2cpg.parser.shared.builders.TemplateAstBuilder;
 
-  FunctionDef thisItem;
-  ParameterListBuilder paramListBuilder = new ParameterListBuilder();
+public class FunctionDefBuilder extends TemplateAstBuilder<FunctionDef> {
+
+  private final ParameterListBuilder paramListBuilder = new ParameterListBuilder();
 
   @Override
   public void createNew(ParserRuleContext ctx) {

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/parser/shared/builders/ClassDefBuilder.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/parser/shared/builders/ClassDefBuilder.java
@@ -1,17 +1,15 @@
 package io.shiftleft.fuzzyc2cpg.parser.shared.builders;
 
+import org.antlr.v4.runtime.ParserRuleContext;
+
 import io.shiftleft.fuzzyc2cpg.FunctionParser;
 import io.shiftleft.fuzzyc2cpg.ModuleParser.Class_nameContext;
-import io.shiftleft.fuzzyc2cpg.ast.AstNodeBuilder;
 import io.shiftleft.fuzzyc2cpg.ast.declarations.ClassDefStatement;
 import io.shiftleft.fuzzyc2cpg.ast.expressions.Identifier;
 import io.shiftleft.fuzzyc2cpg.ast.logical.statements.CompoundStatement;
 import io.shiftleft.fuzzyc2cpg.parser.AstNodeFactory;
-import org.antlr.v4.runtime.ParserRuleContext;
 
-public class ClassDefBuilder extends AstNodeBuilder {
-
-  ClassDefStatement thisItem;
+public class ClassDefBuilder extends TemplateAstBuilder<ClassDefStatement> {
 
   @Override
   public void createNew(ParserRuleContext ctx) {

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/parser/shared/builders/TemplateAstBuilder.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/parser/shared/builders/TemplateAstBuilder.java
@@ -1,0 +1,20 @@
+package io.shiftleft.fuzzyc2cpg.parser.shared.builders;
+
+import io.shiftleft.fuzzyc2cpg.ModuleParser;
+import io.shiftleft.fuzzyc2cpg.ast.AstNode;
+import io.shiftleft.fuzzyc2cpg.ast.AstNodeBuilder;
+import io.shiftleft.fuzzyc2cpg.parser.functions.builder.TemplateParameterListBuilder;
+
+public abstract class TemplateAstBuilder<T extends AstNode> extends AstNodeBuilder {
+  protected T thisItem;
+  protected final TemplateParameterListBuilder templateParamBuilder = new TemplateParameterListBuilder();
+
+  public void setTemplateList(ModuleParser.Template_declContext ctx) {
+    templateParamBuilder.createNew(ctx);
+    thisItem.addChild(templateParamBuilder.getItem());
+  }
+
+  public void addTemplateParameter(ModuleParser.Template_nameContext ctx) {
+    templateParamBuilder.addTemplateParameter(ctx);
+  }
+}

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgConverter.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgConverter.scala
@@ -7,7 +7,7 @@ import io.shiftleft.fuzzyc2cpg.Defines
 import io.shiftleft.fuzzyc2cpg.ast.AstNode
 import io.shiftleft.fuzzyc2cpg.ast.declarations.{ClassDefStatement, IdentifierDecl}
 import io.shiftleft.fuzzyc2cpg.ast.expressions._
-import io.shiftleft.fuzzyc2cpg.ast.functionDef.FunctionDefBase
+import io.shiftleft.fuzzyc2cpg.ast.functionDef.{FunctionDefBase, Template}
 import io.shiftleft.fuzzyc2cpg.ast.langc.expressions.{CallExpression, SizeofExpression}
 import io.shiftleft.fuzzyc2cpg.ast.langc.functiondef.Parameter
 import io.shiftleft.fuzzyc2cpg.ast.langc.statements.blockstarters.IfStatement
@@ -141,6 +141,13 @@ class AstToCpgConverter[NodeBuilderType, NodeType](containingFileName: String,
       parameter.accept(this)
     }
 
+    val templateParamList = astFunction.getTemplateParameterList
+    if (templateParamList != null) {
+      templateParamList.asScala.foreach { template =>
+        template.accept(this)
+      }
+    }
+
     val methodReturnLocation =
       if (astFunction.getReturnType != null) {
         astFunction.getReturnType.getLocation
@@ -185,6 +192,11 @@ class AstToCpgConverter[NodeBuilderType, NodeType](containingFileName: String,
 
     scope.addToScope(astParameter.getName, (cpgParameter, parameterType))
     addAstChild(cpgParameter)
+  }
+
+  override def visit(template: Template): Unit = {
+    // TODO (#60): Populate templated types in CPG.
+    logger.debug("NYI: Template parsing.")
   }
 
   override def visit(argument: Argument): Unit = {
@@ -701,6 +713,13 @@ class AstToCpgConverter[NodeBuilderType, NodeType](containingFileName: String,
       .createNode(astClassDef)
 
     addAstChild(cpgTypeDecl)
+
+    val templateParamList = astClassDef.getTemplateParameterList
+    if (templateParamList != null) {
+      templateParamList.asScala.foreach { template =>
+        template.accept(this)
+      }
+    }
 
     pushContext(cpgTypeDecl, 1, parentIsClassDef = true)
     astClassDef.content.accept(this)

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgConverter.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgConverter.scala
@@ -1,5 +1,7 @@
 package io.shiftleft.fuzzyc2cpg.astnew
 
+import scala.collection.JavaConverters._
+
 import io.shiftleft.codepropertygraph.generated.{EvaluationStrategies, Operators}
 import io.shiftleft.fuzzyc2cpg.Defines
 import io.shiftleft.fuzzyc2cpg.ast.AstNode
@@ -18,8 +20,6 @@ import io.shiftleft.fuzzyc2cpg.astnew.NodeProperty.NodeProperty
 import io.shiftleft.fuzzyc2cpg.scope.Scope
 import io.shiftleft.proto.cpg.Cpg.DispatchTypes
 import org.slf4j.LoggerFactory
-
-import scala.collection.JavaConverters._
 
 object AstToCpgConverter {
   private val logger = LoggerFactory.getLogger(getClass)

--- a/src/test/java/io/shiftleft/fuzzyc2cpg/antlrparsers/moduleparser/ClassDeclarationTest.java
+++ b/src/test/java/io/shiftleft/fuzzyc2cpg/antlrparsers/moduleparser/ClassDeclarationTest.java
@@ -30,7 +30,7 @@ public class ClassDeclarationTest
 		ModuleParser parser = createParser(input);
 		String output = parser.simple_decl().toStringTree(parser);
 		assertTrue(output.startsWith(
-				"(simple_decl (var_decl (class_def struct (class_name (identifier foo))"));
+				"(simple_decl (var_decl (class_def (class_key struct) (class_name (identifier foo))"));
 	}
 
 	@Test
@@ -41,7 +41,7 @@ public class ClassDeclarationTest
 		ModuleParser parser = createParser(input);
 		String output = parser.simple_decl().toStringTree(parser);
 		assertTrue(output
-				.startsWith("(simple_decl (var_decl (class_def struct {"));
+				.startsWith("(simple_decl (var_decl (class_def (class_key struct) {"));
 	}
 
 	@Test
@@ -64,7 +64,7 @@ public class ClassDeclarationTest
 		ModuleParser parser = createParser(input);
 		String output = parser.simple_decl().toStringTree(parser);
 		assertTrue(output.startsWith(
-				"(simple_decl (var_decl (class_def struct (class_name (identifier foo)) { int x ; }) (init_declarator_list (init_declarator (declarator (identifier y))) ;)))"));
+				"(simple_decl (var_decl (class_def (class_key struct) (class_name (identifier foo)) { int x ; }) (init_declarator_list (init_declarator (declarator (identifier y))) ;)))"));
 	}
 
 	@Test

--- a/src/test/java/io/shiftleft/fuzzyc2cpg/antlrparsers/moduleparser/TemplateTests.java
+++ b/src/test/java/io/shiftleft/fuzzyc2cpg/antlrparsers/moduleparser/TemplateTests.java
@@ -26,10 +26,10 @@ public class TemplateTests extends ModuleParserTest {
 
   @Test
   public void testClassTemplateTemplate() {
-    String input = "template <template<typename, typename> M, typename K, typename V> class Foo {};";
+    String input = "template <template<typename, typename> typename M, typename K, typename V> class Foo {};";
     ModuleParser parser = createParser(input);
     String output = parser.class_def().toStringTree(parser);
-    assertTrue(output.contains("(class_def (template_decl template < (template_decl_param_list (template_decl_param_list (template_decl_param_list (template_template template < (template_decl_keyword typename) , (template_decl_keyword typename) >) (template_name M)) , (template_decl_param (template_decl_keyword typename) (template_name K))) , (template_decl_param (template_decl_keyword typename) (template_name V))) >) (class_key class) (class_name (identifier Foo)) { })"));
+    assertTrue(output.contains("(class_def (template_decl template < (template_decl_param_list (template_decl_param_list (template_decl_param_list (template_template template < (template_decl_keyword typename) , (template_decl_keyword typename) >) (template_decl_keyword typename) (template_name M)) , (template_decl_param (template_decl_keyword typename) (template_name K))) , (template_decl_param (template_decl_keyword typename) (template_name V))) >) (class_key class) (class_name (identifier Foo)) { })"));
   }
 
   @Test
@@ -66,10 +66,10 @@ public class TemplateTests extends ModuleParserTest {
 
   @Test
   public void testFunctionTemplateTemplate() {
-    String input = "template <template <typename, typename> M, typename K, typename V> M<K, V> foo(M<K, V> k) {}";
+    String input = "template <template <typename, typename> typename M, typename K, typename V> M<K, V> foo(M<K, V> k) {}";
     ModuleParser parser = createParser(input);
     String output = parser.function_def().toStringTree(parser);
-    assertTrue(output.contains("(function_def (template_decl template < (template_decl_param_list (template_decl_param_list (template_decl_param_list (template_template template < (template_decl_keyword typename) , (template_decl_keyword typename) >) (template_name M)) , (template_decl_param (template_decl_keyword typename) (template_name K))) , (template_decl_param (template_decl_keyword typename) (template_name V))) >) (return_type (type_name (base_type M) < (template_args (base_type K) , (base_type V)) >)) (function_name (identifier foo)) (function_param_list ( (parameter_decl_clause (parameter_decl (param_decl_specifiers (type_name (base_type M) < (template_args (base_type K) , (base_type V)) >)) (parameter_id (parameter_name (identifier k))))) )) (compound_statement { }))"));
+    assertTrue(output.contains("(function_def (template_decl template < (template_decl_param_list (template_decl_param_list (template_decl_param_list (template_template template < (template_decl_keyword typename) , (template_decl_keyword typename) >) (template_decl_keyword typename) (template_name M)) , (template_decl_param (template_decl_keyword typename) (template_name K))) , (template_decl_param (template_decl_keyword typename) (template_name V))) >) (return_type (type_name (base_type M) < (template_args (base_type K) , (base_type V)) >)) (function_name (identifier foo)) (function_param_list ( (parameter_decl_clause (parameter_decl (param_decl_specifiers (type_name (base_type M) < (template_args (base_type K) , (base_type V)) >)) (parameter_id (parameter_name (identifier k))))) )) (compound_statement { }))"));
   }
 
   @Test
@@ -106,10 +106,10 @@ public class TemplateTests extends ModuleParserTest {
 
   @Test
   public void testFunctionDeclTemplateTemplate() {
-    String input = "template <template <typename, typename> M, typename K, typename V> M<K, V> foo(M<K, V> k);";
+    String input = "template <template <typename, typename> typename M, typename K, typename V> M<K, V> foo(M<K, V> k);";
     ModuleParser parser = createParser(input);
     String output = parser.function_decl().toStringTree(parser);
-    assertTrue(output.contains("(function_decl (template_decl template < (template_decl_param_list (template_decl_param_list (template_decl_param_list (template_template template < (template_decl_keyword typename) , (template_decl_keyword typename) >) (template_name M)) , (template_decl_param (template_decl_keyword typename) (template_name K))) , (template_decl_param (template_decl_keyword typename) (template_name V))) >) (return_type (type_name (base_type M) < (template_args (base_type K) , (base_type V)) >)) (function_name (identifier foo)) (function_param_list ( (parameter_decl_clause (parameter_decl (param_decl_specifiers (type_name (base_type M) < (template_args (base_type K) , (base_type V)) >)) (parameter_id (parameter_name (identifier k))))) )) ;)"));
+    assertTrue(output.contains("(function_decl (template_decl template < (template_decl_param_list (template_decl_param_list (template_decl_param_list (template_template template < (template_decl_keyword typename) , (template_decl_keyword typename) >) (template_decl_keyword typename) (template_name M)) , (template_decl_param (template_decl_keyword typename) (template_name K))) , (template_decl_param (template_decl_keyword typename) (template_name V))) >) (return_type (type_name (base_type M) < (template_args (base_type K) , (base_type V)) >)) (function_name (identifier foo)) (function_param_list ( (parameter_decl_clause (parameter_decl (param_decl_specifiers (type_name (base_type M) < (template_args (base_type K) , (base_type V)) >)) (parameter_id (parameter_name (identifier k))))) )) ;)"));
   }
 
   @Test

--- a/src/test/java/io/shiftleft/fuzzyc2cpg/antlrparsers/moduleparser/TemplateTests.java
+++ b/src/test/java/io/shiftleft/fuzzyc2cpg/antlrparsers/moduleparser/TemplateTests.java
@@ -1,0 +1,130 @@
+package io.shiftleft.fuzzyc2cpg.antlrparsers.moduleparser;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import io.shiftleft.fuzzyc2cpg.ModuleParser;
+
+public class TemplateTests extends ModuleParserTest {
+
+  @Test
+  public void testClassTemplate() {
+    String input = "template <typename T> class Foo {};";
+    ModuleParser parser = createParser(input);
+    String output = parser.class_def().toStringTree(parser);
+    assertTrue(output.contains("(class_def (template_decl template < (template_decl_param_list (template_decl_param (template_decl_keyword typename) (template_name T))) >) (class_key class) (class_name (identifier Foo)) { })"));
+  }
+
+  @Test
+  public void testMultipleClassTemplate() {
+    String input = "template <typename K, typename V> class Foo {};";
+    ModuleParser parser = createParser(input);
+    String output = parser.class_def().toStringTree(parser);
+    assertTrue(output.contains("(class_def (template_decl template < (template_decl_param_list (template_decl_param_list (template_decl_param (template_decl_keyword typename) (template_name K))) , (template_decl_param (template_decl_keyword typename) (template_name V))) >) (class_key class) (class_name (identifier Foo)) { })"));
+  }
+
+  @Test
+  public void testClassTemplateTemplate() {
+    String input = "template <template<typename, typename> M, typename K, typename V> class Foo {};";
+    ModuleParser parser = createParser(input);
+    String output = parser.class_def().toStringTree(parser);
+    assertTrue(output.contains("(class_def (template_decl template < (template_decl_param_list (template_decl_param_list (template_decl_param_list (template_template template < (template_decl_keyword typename) , (template_decl_keyword typename) >) (template_name M)) , (template_decl_param (template_decl_keyword typename) (template_name K))) , (template_decl_param (template_decl_keyword typename) (template_name V))) >) (class_key class) (class_name (identifier Foo)) { })"));
+  }
+
+  @Test
+  public void testSpecializedClassTemplate() {
+    String input = "template <> class Foo<int> {};";
+    ModuleParser parser = createParser(input);
+    String output = parser.class_def().toStringTree(parser);
+    assertTrue(output.contains("(class_def (template_decl template < >) (class_key class) (class_name (identifier Foo)) (template_args < (template_args (base_type int)) >) { })"));
+  }
+
+  @Test
+  public void testVariadicClassTemplate() {
+    String input = "template <typename Args...> class Foo {};";
+    ModuleParser parser = createParser(input);
+    String output = parser.class_def().toStringTree(parser);
+    assertTrue(output.contains("(class_def (template_decl template < (template_decl_param_list (template_decl_param (template_decl_keyword typename) (template_name Args ...))) >) (class_key class) (class_name (identifier Foo)) { })"));
+  }
+
+  @Test
+  public void testFunctionTemplate() {
+    String input = "template <typename T> T foo(T t) {}";
+    ModuleParser parser = createParser(input);
+    String output = parser.function_def().toStringTree(parser);
+    assertTrue(output.contains("(function_def (template_decl template < (template_decl_param_list (template_decl_param (template_decl_keyword typename) (template_name T))) >) (return_type (type_name (base_type T))) (function_name (identifier foo)) (function_param_list ( (parameter_decl_clause (parameter_decl (param_decl_specifiers (type_name (base_type T))) (parameter_id (parameter_name (identifier t))))) )) (compound_statement { }))"));
+  }
+
+  @Test
+  public void testMultipleFunctionTemplate() {
+    String input = "template <typename K, typename V> V foo(K k) {}";
+    ModuleParser parser = createParser(input);
+    String output = parser.function_def().toStringTree(parser);
+    assertTrue(output.contains("(function_def (template_decl template < (template_decl_param_list (template_decl_param_list (template_decl_param (template_decl_keyword typename) (template_name K))) , (template_decl_param (template_decl_keyword typename) (template_name V))) >) (return_type (type_name (base_type V))) (function_name (identifier foo)) (function_param_list ( (parameter_decl_clause (parameter_decl (param_decl_specifiers (type_name (base_type K))) (parameter_id (parameter_name (identifier k))))) )) (compound_statement { }))") );
+  }
+
+  @Test
+  public void testFunctionTemplateTemplate() {
+    String input = "template <template <typename, typename> M, typename K, typename V> M<K, V> foo(M<K, V> k) {}";
+    ModuleParser parser = createParser(input);
+    String output = parser.function_def().toStringTree(parser);
+    assertTrue(output.contains("(function_def (template_decl template < (template_decl_param_list (template_decl_param_list (template_decl_param_list (template_template template < (template_decl_keyword typename) , (template_decl_keyword typename) >) (template_name M)) , (template_decl_param (template_decl_keyword typename) (template_name K))) , (template_decl_param (template_decl_keyword typename) (template_name V))) >) (return_type (type_name (base_type M) < (template_args (base_type K) , (base_type V)) >)) (function_name (identifier foo)) (function_param_list ( (parameter_decl_clause (parameter_decl (param_decl_specifiers (type_name (base_type M) < (template_args (base_type K) , (base_type V)) >)) (parameter_id (parameter_name (identifier k))))) )) (compound_statement { }))"));
+  }
+
+  @Test
+  public void testSpecializedFunctionTemplate() {
+    String input = "template <> int foo(int y) {}";
+    ModuleParser parser = createParser(input);
+    String output = parser.function_def().toStringTree(parser);
+    assertTrue(output.contains("(function_def (template_decl template < >) (return_type (type_name (base_type int))) (function_name (identifier foo)) (function_param_list ( (parameter_decl_clause (parameter_decl (param_decl_specifiers (type_name (base_type int))) (parameter_id (parameter_name (identifier y))))) )) (compound_statement { }))"));
+  }
+
+  @Test
+  public void testVariadicFunctionTemplate() {
+    String input = "template <typename Args...> int Foo(Args... args) {};";
+    ModuleParser parser = createParser(input);
+    String output = parser.function_def().toStringTree(parser);
+    assertTrue(output.contains("(function_def (template_decl template < (template_decl_param_list (template_decl_param (template_decl_keyword typename) (template_name Args ...))) >) (return_type (type_name (base_type int))) (function_name (identifier Foo)) (function_param_list ( (parameter_decl_clause (parameter_decl (param_decl_specifiers (type_name (base_type Args))) (parameter_id ... (parameter_name (identifier args))))) )) (compound_statement { }))"));
+  }
+
+  @Test
+  public void testFunctionDeclTemplate() {
+    String input = "template <typename T> T foo(T t);";
+    ModuleParser parser = createParser(input);
+    String output = parser.function_decl().toStringTree(parser);
+    assertTrue(output.contains("(function_decl (template_decl template < (template_decl_param_list (template_decl_param (template_decl_keyword typename) (template_name T))) >) (return_type (type_name (base_type T))) (function_name (identifier foo)) (function_param_list ( (parameter_decl_clause (parameter_decl (param_decl_specifiers (type_name (base_type T))) (parameter_id (parameter_name (identifier t))))) )) ;)"));
+  }
+
+  @Test
+  public void testMultipleFunctionDeclTemplate() {
+    String input = "template <typename K, typename V> V foo(K k);";
+    ModuleParser parser = createParser(input);
+    String output = parser.function_decl().toStringTree(parser);
+    assertTrue(output.contains("(function_decl (template_decl template < (template_decl_param_list (template_decl_param_list (template_decl_param (template_decl_keyword typename) (template_name K))) , (template_decl_param (template_decl_keyword typename) (template_name V))) >) (return_type (type_name (base_type V))) (function_name (identifier foo)) (function_param_list ( (parameter_decl_clause (parameter_decl (param_decl_specifiers (type_name (base_type K))) (parameter_id (parameter_name (identifier k))))) )) ;)") );
+  }
+
+  @Test
+  public void testFunctionDeclTemplateTemplate() {
+    String input = "template <template <typename, typename> M, typename K, typename V> M<K, V> foo(M<K, V> k);";
+    ModuleParser parser = createParser(input);
+    String output = parser.function_decl().toStringTree(parser);
+    assertTrue(output.contains("(function_decl (template_decl template < (template_decl_param_list (template_decl_param_list (template_decl_param_list (template_template template < (template_decl_keyword typename) , (template_decl_keyword typename) >) (template_name M)) , (template_decl_param (template_decl_keyword typename) (template_name K))) , (template_decl_param (template_decl_keyword typename) (template_name V))) >) (return_type (type_name (base_type M) < (template_args (base_type K) , (base_type V)) >)) (function_name (identifier foo)) (function_param_list ( (parameter_decl_clause (parameter_decl (param_decl_specifiers (type_name (base_type M) < (template_args (base_type K) , (base_type V)) >)) (parameter_id (parameter_name (identifier k))))) )) ;)"));
+  }
+
+  @Test
+  public void testSpecializedFunctionDeclTemplate() {
+    String input = "template <> int foo(int y);";
+    ModuleParser parser = createParser(input);
+    String output = parser.function_decl().toStringTree(parser);
+    assertTrue(output.contains("(function_decl (template_decl template < >) (return_type (type_name (base_type int))) (function_name (identifier foo)) (function_param_list ( (parameter_decl_clause (parameter_decl (param_decl_specifiers (type_name (base_type int))) (parameter_id (parameter_name (identifier y))))) )) ;)"));
+  }
+
+  @Test
+  public void testVariadicFunctionDeclTemplate() {
+    String input = "template <typename Args...> int Foo(Args... args) {};";
+    ModuleParser parser = createParser(input);
+    String output = parser.function_decl().toStringTree(parser);
+    assertTrue(output.contains("(function_decl (template_decl template < (template_decl_param_list (template_decl_param (template_decl_keyword typename) (template_name Args ...))) >) (return_type (type_name (base_type int))) (function_name (identifier Foo)) (function_param_list ( (parameter_decl_clause (parameter_decl (param_decl_specifiers (type_name (base_type Args))) (parameter_id ... (parameter_name (identifier args))))) )) { } ;)"));
+  }
+}

--- a/src/test/java/io/shiftleft/fuzzyc2cpg/parsetreetoast/ModuleBuildersTest.java
+++ b/src/test/java/io/shiftleft/fuzzyc2cpg/parsetreetoast/ModuleBuildersTest.java
@@ -252,7 +252,7 @@ public class ModuleBuildersTest
 
 	@Test
 	public void testTemplateTemplateAssociationWithClass() {
-		String input = "template <template<typename> T, typename Z> class Foo { T<Z> t; };";
+		String input = "template <template<typename> typename T, typename Z> class Foo { T<Z> t; };";
 		List<AstNode> codeItems = parseInput(input);
 		ClassDefStatement classDef = (ClassDefStatement) codeItems.get(0);
 		TemplateParameterList templates = (TemplateParameterList) classDef.getChild(0);
@@ -292,7 +292,7 @@ public class ModuleBuildersTest
 
 	@Test
 	public void testTemplateTemplateAssociationWithFunction() {
-		String input = "template <template<typename> T, typename Z> T<Z> foo(T<Z> x) { }";
+		String input = "template <template<typename> typename T, typename Z> T<Z> foo(T<Z> x) { }";
 		List<AstNode> codeItems = parseInput(input);
 		FunctionDef functionDef = (FunctionDef) codeItems.get(0);
 		TemplateParameterList templates = (TemplateParameterList) functionDef.getChild(1);
@@ -332,7 +332,7 @@ public class ModuleBuildersTest
 
 	@Test
 	public void testTemplateTemplateAssociationWithFunctionDecl() {
-		String input = "template <template<typename> T, typename Z> T<Z> foo(T<Z> x);";
+		String input = "template <template<typename> typename T, typename Z> T<Z> foo(T<Z> x);";
 		List<AstNode> codeItems = parseInput(input);
 		FunctionDef functionDef = (FunctionDef) codeItems.get(0);
 		TemplateParameterList templates = (TemplateParameterList) functionDef.getChild(1);

--- a/src/test/java/io/shiftleft/fuzzyc2cpg/parsetreetoast/ModuleBuildersTest.java
+++ b/src/test/java/io/shiftleft/fuzzyc2cpg/parsetreetoast/ModuleBuildersTest.java
@@ -3,21 +3,25 @@ package io.shiftleft.fuzzyc2cpg.parsetreetoast;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.util.List;
+
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.CharStreams;
+import org.junit.Test;
+
 import io.shiftleft.fuzzyc2cpg.ModuleLexer;
 import io.shiftleft.fuzzyc2cpg.ast.AstNode;
 import io.shiftleft.fuzzyc2cpg.ast.declarations.ClassDefStatement;
 import io.shiftleft.fuzzyc2cpg.ast.declarations.IdentifierDecl;
 import io.shiftleft.fuzzyc2cpg.ast.functionDef.FunctionDefBase;
 import io.shiftleft.fuzzyc2cpg.ast.functionDef.ParameterBase;
+import io.shiftleft.fuzzyc2cpg.ast.functionDef.Template;
+import io.shiftleft.fuzzyc2cpg.ast.functionDef.TemplateParameterList;
+import io.shiftleft.fuzzyc2cpg.ast.langc.functiondef.FunctionDef;
 import io.shiftleft.fuzzyc2cpg.ast.langc.functiondef.ParameterType;
 import io.shiftleft.fuzzyc2cpg.ast.statements.IdentifierDeclStatement;
 import io.shiftleft.fuzzyc2cpg.parser.TokenSubStream;
 import io.shiftleft.fuzzyc2cpg.parser.modules.AntlrCModuleParserDriver;
-import java.util.List;
-
-import org.antlr.v4.runtime.CharStream;
-import org.antlr.v4.runtime.CharStreams;
-import org.junit.Test;
 
 public class ModuleBuildersTest
 {
@@ -227,6 +231,123 @@ public class ModuleBuildersTest
 		List<AstNode> codeItems = parseInput(input);
 		FunctionDefBase codeItem = (FunctionDefBase) codeItems.get(0);
 		assertTrue(codeItem.getParameterList().size() == 0);
+	}
+
+	@Test
+	public void testTemplateAssociationWithClass() {
+		String input = "template <typename T> class Foo { T t; };";
+		List<AstNode> codeItems = parseInput(input);
+		ClassDefStatement classDef = (ClassDefStatement) codeItems.get(0);
+		TemplateParameterList templates = (TemplateParameterList) classDef.getChild(0);
+
+		assertEquals("Foo", classDef.getIdentifier().getEscapedCodeStr());
+		assertEquals(1, templates.getChildCount());
+		assertEquals(1, templates.size());
+
+		Template template = (Template) templates.getChild(0);
+
+		assertEquals(1, template.getChildCount());
+		assertEquals("T", template.getName());
+	}
+
+	@Test
+	public void testTemplateTemplateAssociationWithClass() {
+		String input = "template <template<typename> T, typename Z> class Foo { T<Z> t; };";
+		List<AstNode> codeItems = parseInput(input);
+		ClassDefStatement classDef = (ClassDefStatement) codeItems.get(0);
+		TemplateParameterList templates = (TemplateParameterList) classDef.getChild(0);
+
+		assertEquals("Foo", classDef.getIdentifier().getEscapedCodeStr());
+		assertEquals(2, templates.size());
+		assertEquals(2, templates.getChildCount());
+
+		Template firstTemplate = (Template) templates.getChild(0);
+		Template secondTemplate = (Template) templates.getChild(1);
+
+		assertEquals(1, firstTemplate.getChildCount());
+		assertEquals(1, secondTemplate.getChildCount());
+		assertEquals("T", firstTemplate.getName());
+		assertEquals("Z", secondTemplate.getName());
+	}
+
+	@Test
+	public void testTemplateAssociationWithFunction() {
+		String input = "template <typename T, typename Z> T foo(T x) { }";
+		List<AstNode> codeItems = parseInput(input);
+		FunctionDef functionDef = (FunctionDef) codeItems.get(0);
+		TemplateParameterList templates = (TemplateParameterList) functionDef.getChild(1);
+
+		assertEquals("foo", functionDef.getIdentifier().getEscapedCodeStr());
+		assertEquals(2, templates.size());
+		assertEquals(2, templates.getChildCount());
+
+		Template firstTemplate = (Template) templates.getChild(0);
+		Template secondTemplate = (Template) templates.getChild(1);
+
+		assertEquals(1, firstTemplate.getChildCount());
+		assertEquals(1, secondTemplate.getChildCount());
+		assertEquals("T", firstTemplate.getName());
+		assertEquals("Z", secondTemplate.getName());
+	}
+
+	@Test
+	public void testTemplateTemplateAssociationWithFunction() {
+		String input = "template <template<typename> T, typename Z> T<Z> foo(T<Z> x) { }";
+		List<AstNode> codeItems = parseInput(input);
+		FunctionDef functionDef = (FunctionDef) codeItems.get(0);
+		TemplateParameterList templates = (TemplateParameterList) functionDef.getChild(1);
+
+		assertEquals("foo", functionDef.getIdentifier().getEscapedCodeStr());
+		assertEquals(2, templates.size());
+		assertEquals(2, templates.getChildCount());
+
+		Template firstTemplate = (Template) templates.getChild(0);
+		Template secondTemplate = (Template) templates.getChild(1);
+
+		assertEquals(1, firstTemplate.getChildCount());
+		assertEquals(1, secondTemplate.getChildCount());
+		assertEquals("T", firstTemplate.getName());
+		assertEquals("Z", secondTemplate.getName());
+	}
+
+	@Test
+	public void testTemplateAssociationWithFunctionDecl() {
+		String input = "template <typename T, typename Z> T foo(T x);";
+		List<AstNode> codeItems = parseInput(input);
+		FunctionDef functionDef = (FunctionDef) codeItems.get(0);
+		TemplateParameterList templates = (TemplateParameterList) functionDef.getChild(1);
+
+		assertEquals("foo", functionDef.getIdentifier().getEscapedCodeStr());
+		assertEquals(2, templates.size());
+		assertEquals(2, templates.getChildCount());
+
+		Template firstTemplate = (Template) templates.getChild(0);
+		Template secondTemplate = (Template) templates.getChild(1);
+
+		assertEquals(1, firstTemplate.getChildCount());
+		assertEquals(1, secondTemplate.getChildCount());
+		assertEquals("T", firstTemplate.getName());
+		assertEquals("Z", secondTemplate.getName());
+	}
+
+	@Test
+	public void testTemplateTemplateAssociationWithFunctionDecl() {
+		String input = "template <template<typename> T, typename Z> T<Z> foo(T<Z> x);";
+		List<AstNode> codeItems = parseInput(input);
+		FunctionDef functionDef = (FunctionDef) codeItems.get(0);
+		TemplateParameterList templates = (TemplateParameterList) functionDef.getChild(1);
+
+		assertEquals("foo", functionDef.getIdentifier().getEscapedCodeStr());
+		assertEquals(2, templates.size());
+		assertEquals(2, templates.getChildCount());
+
+		Template firstTemplate = (Template) templates.getChild(0);
+		Template secondTemplate = (Template) templates.getChild(1);
+
+		assertEquals(1, firstTemplate.getChildCount());
+		assertEquals(1, secondTemplate.getChildCount());
+		assertEquals("T", firstTemplate.getName());
+		assertEquals("Z", secondTemplate.getName());
 	}
 
 	private List<AstNode> parseInput(String input)


### PR DESCRIPTION
- Add extensive support for function and class templates, including template-templates, specialized templates and variadic templates.

Currently WIP: Support for template default values.

This PR does *not* generate `TYPE_PARAMETER` nodes. This will be included in a follow-up PR.