### PR TITLE
Do not use OverflowDb in Ast tests.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,6 +15,7 @@ libraryDependencies ++= Seq(
   "com.novocode" % "junit-interface" % "0.11" % Test,
   "junit" % "junit" % "4.12" % Test,
   "org.scalatest" %% "scalatest" % "3.0.3" % Test,
+  "org.apache.tinkerpop" % "tinkergraph-gremlin" % "3.4.3" % Test,
 )
 
 // uncomment if you want to use a cpg version that has *just* been released

--- a/src/test/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgTests.scala
+++ b/src/test/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgTests.scala
@@ -1,7 +1,6 @@
 package io.shiftleft.fuzzyc2cpg.astnew
 
 import gremlin.scala._
-import io.shiftleft.codepropertygraph.generated
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeKeys, NodeTypes, Operators}
 import io.shiftleft.fuzzyc2cpg.ModuleLexer
 import io.shiftleft.fuzzyc2cpg.ast.{AstNode, AstNodeBuilder}
@@ -10,8 +9,8 @@ import io.shiftleft.fuzzyc2cpg.astnew.NodeKind.NodeKind
 import io.shiftleft.fuzzyc2cpg.astnew.NodeProperty.NodeProperty
 import io.shiftleft.fuzzyc2cpg.parser.modules.AntlrCModuleParserDriver
 import io.shiftleft.fuzzyc2cpg.parser.{AntlrParserDriverObserver, TokenSubStream}
-import io.shiftleft.overflowdb.{OdbConfig, OdbGraph}
 import org.antlr.v4.runtime.{CharStreams, ParserRuleContext}
+import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph
 import org.scalatest.{Matchers, WordSpec}
 
 class AstToCpgTests extends WordSpec with Matchers {
@@ -102,9 +101,7 @@ class AstToCpgTests extends WordSpec with Matchers {
     driver.parseAndWalkTokenStream(tokens)
 
     private val fileName = "codeFromString"
-    val graph: ScalaGraph = OdbGraph.open(OdbConfig.withoutOverflow(),
-                                          generated.nodes.Factories.AllAsJava,
-                                          generated.edges.Factories.AllAsJava)
+    val graph: ScalaGraph = TinkerGraph.open()
     private val astParentNode = graph.addVertex("NAMESPACE_BLOCK")
     protected val astParent = List(astParentNode)
     private val cpgAdapter = new GraphAdapter(graph)


### PR DESCRIPTION
We do not want this because OverflowDb requires schema information
about the graph which brings in a dependency the generate domain
classes from the codepropertygraph repository.