### PR TITLE
Fix ordering of executable flags.

### DIFF
--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
@@ -44,8 +44,8 @@ class FuzzyC2Cpg(outputModuleFactory: CpgOutputModuleFactory) {
     val sourceFileNames = SourceFiles.determine(sourcePaths, sourceFileExtensions)
 
     val cmd = Seq(
-      "--verbose",
       preprocessorExecutable,
+      "--verbose",
       "-o",
       preprocessedPath.toString,
       "-f",


### PR DESCRIPTION
The `--verbose` flag came before the actual executable name

![](http://i0.wp.com/www.therefinedgeek.com.au/wp-content/uploads/2013/09/Picard-Facepalm.jpg?fit=1200%2C9999)