### PR TITLE
Skip any compilation units we can't parse

### DIFF
--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
@@ -169,17 +169,15 @@ class FuzzyC2Cpg(outputModuleFactory: CpgOutputModuleFactory) {
     driver.setNamespaceBlock(namespaceBlock);
     driver.setFileNode(fileNode)
 
-
     try {
       driver.parseAndWalkFile(filename)
     } catch {
-      case ex : RuntimeException => {
+      case ex: RuntimeException => {
         logger.warn("Cannot parse module: " + filename + ", skipping")
         logger.warn("Complete exception: ", ex)
         return
       }
     }
-
 
     val outputModule = outputModuleFactory.create()
     outputModule.setOutputIdentifier(

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
@@ -168,7 +168,18 @@ class FuzzyC2Cpg(outputModuleFactory: CpgOutputModuleFactory) {
     driver.setCpg(cpg);
     driver.setNamespaceBlock(namespaceBlock);
     driver.setFileNode(fileNode)
-    driver.parseAndWalkFile(filename)
+
+
+    try {
+      driver.parseAndWalkFile(filename)
+    } catch {
+      case ex : RuntimeException => {
+        logger.warn("Cannot parse module: " + filename + ", skipping")
+        logger.warn("Complete exception: ", ex)
+        return
+      }
+    }
+
 
     val outputModule = outputModuleFactory.create()
     outputModule.setOutputIdentifier(


### PR DESCRIPTION
To be more resilient, we now catch RuntimeExceptions when parsing compilation units. Exceptions are logged and the compilation unit is skipped.