### PR TITLE
Store absolute paths in FILE nodes

### DIFF
--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
@@ -117,7 +117,7 @@ class FuzzyC2Cpg(outputModuleFactory: CpgOutputModuleFactory) {
 
     def createFileNode(pathToFile: Path): Node = {
       newNode(NodeType.FILE)
-        .addStringProperty(NodePropertyName.NAME, pathToFile.toString)
+        .addStringProperty(NodePropertyName.NAME, pathToFile.toAbsolutePath.toString)
         .build()
     }
 

--- a/src/test/scala/io/shiftleft/fuzzyc2cpg/ProgramStructureTests.scala
+++ b/src/test/scala/io/shiftleft/fuzzyc2cpg/ProgramStructureTests.scala
@@ -25,7 +25,8 @@ class ProgramStructureTests extends WordSpec with Matchers {
         .value(NodeKeys.NAME)
         .headOption
       fileName.isDefined shouldBe true
-      fileName.head shouldBe "src/test/resources/testcode/structure/structure.c"
+      fileName.head should not be "src/test/resources/testcode/structure/structure.c"
+      fileName.head should endWith("src/test/resources/testcode/structure/structure.c")
     }
 
     "contain AST edge from file node to namespace block" in {


### PR DESCRIPTION
We were storing relative paths in FILE nodes, which is problematic when `joern-parse` is run from one directory and `joern` from another. I am making these paths absolute in preparation for a new feature that allows us to browse code on the joern/ocular shell.