### PR TITLE
Normalize paths stored in FILE nodes

### DIFF
--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
@@ -117,7 +117,7 @@ class FuzzyC2Cpg(outputModuleFactory: CpgOutputModuleFactory) {
 
     def createFileNode(pathToFile: Path): Node = {
       newNode(NodeType.FILE)
-        .addStringProperty(NodePropertyName.NAME, pathToFile.toAbsolutePath.toString)
+        .addStringProperty(NodePropertyName.NAME, pathToFile.toAbsolutePath.normalize.toString)
         .build()
     }
 

--- a/src/test/scala/io/shiftleft/fuzzyc2cpg/ProgramStructureTests.scala
+++ b/src/test/scala/io/shiftleft/fuzzyc2cpg/ProgramStructureTests.scala
@@ -25,6 +25,7 @@ class ProgramStructureTests extends WordSpec with Matchers {
         .value(NodeKeys.NAME)
         .headOption
       fileName.isDefined shouldBe true
+      fileName.head should not contain ".."
       fileName.head should not be "src/test/resources/testcode/structure/structure.c"
       fileName.head should endWith("src/test/resources/testcode/structure/structure.c")
     }

--- a/src/test/scala/io/shiftleft/fuzzyc2cpg/cfg/AstToCfgTests.scala
+++ b/src/test/scala/io/shiftleft/fuzzyc2cpg/cfg/AstToCfgTests.scala
@@ -47,7 +47,6 @@ class AstToCfgTests extends WordSpec with Matchers {
     override def addNodeProperty(nodeBuilder: CfgNode, property: NodeProperty, value: Boolean): Unit = ???
     override def addNodeProperty(nodeBuilder: CfgNode, property: NodeProperty, value: List[String]): Unit = ???
 
-
     override def createEdgeBuilder(dst: CfgNode, src: CfgNode, edgeKind: EdgeKind): CfgNodeEdgePairBuilder = {
       if (src.successors.exists(_.cfgNode == dst)) {
         throw new RuntimeException("Found duplicate edge.")


### PR DESCRIPTION
This is a follow-up to https://github.com/ShiftLeftSecurity/fuzzyc2cpg/pull/136 - it's not enough for the path to be absolute, it needs to also be relative to remove any ".." sequences.