### PR TITLE
Fix issues with template parsing.

### DIFF
--- a/src/main/antlr4/io/shiftleft/fuzzyc2cpg/Common.g4
+++ b/src/main/antlr4/io/shiftleft/fuzzyc2cpg/Common.g4
@@ -110,11 +110,11 @@ template_decl_param_list: template_template template_decl_keyword template_name 
                           template_decl_param |
                           template_decl_param_list ',' template_decl_param;
 template_template: TEMPLATE '<' (template_decl_keyword ','?)+ '>';
-template_decl_param: template_decl_keyword template_name?;
+template_decl_param: (template_decl_keyword | identifier) template_name?;
 template_decl_keyword: 'typename' | 'class';
 template_name: ALPHA_NUMERIC+ ELLIPSIS? ;
 
-template_args: ('<' template_args '>' | '(' template_args ')' | base_type ELLIPSIS? | ',')+;
+template_args: ('<' template_args '>' | '(' template_args ')' | CV_QUALIFIER? base_type ELLIPSIS? | ',')+;
 
 // water
 
@@ -140,13 +140,14 @@ number: HEX_LITERAL | DECIMAL_LITERAL | OCTAL_LITERAL;
 
 ptrs: (CV_QUALIFIER? ptr_operator 'restrict'?)+;
 func_ptrs: ptrs;
+rvalue_ref: '&&';
 
 class_key: 'struct' | 'class' | 'union' | 'enum';
 
-class_def: template_decl? class_key gcc_attribute? class_name? template_args? base_classes? OPENING_CURLY {skipToEndOfObject(); } ;
+class_def: template_decl* class_key gcc_attribute? class_name? template_args? base_classes? OPENING_CURLY {skipToEndOfObject(); } ;
 class_name: identifier;
 base_classes: ':' base_class (',' base_class)*;
-base_class: VIRTUAL? access_specifier? identifier;
+base_class: VIRTUAL? access_specifier? identifier template_args?;
 
 
 type_name : (CV_QUALIFIER* (class_key | UNSIGNED | SIGNED)?
@@ -155,7 +156,7 @@ type_name : (CV_QUALIFIER* (class_key | UNSIGNED | SIGNED)?
           | SIGNED
           ;
 
-base_type: (ALPHA_NUMERIC | AUTO | VOID | LONG | LONG)+;
+base_type: ((ALPHA_NUMERIC | AUTO | VOID | LONG | LONG) ELLIPSIS?)+;
 
 gcc_attribute: GCC_ATTRIBUTE '(' '(' identifier ')' ')';
 

--- a/src/main/antlr4/io/shiftleft/fuzzyc2cpg/Function.g4
+++ b/src/main/antlr4/io/shiftleft/fuzzyc2cpg/Function.g4
@@ -100,4 +100,4 @@ param_type_list: '(' VOID ')'
                | '(' (param_type (',' param_type)*)? ')';
 
 param_type: param_decl_specifiers param_type_id;
-param_type_id: ptrs? ('(' param_type_id ')' | parameter_name?) type_suffix?;
+param_type_id: (ptrs | rvalue_ref)? ('(' param_type_id ')' | parameter_name?) type_suffix?;

--- a/src/main/antlr4/io/shiftleft/fuzzyc2cpg/Module.g4
+++ b/src/main/antlr4/io/shiftleft/fuzzyc2cpg/Module.g4
@@ -22,9 +22,9 @@ code : (function_decl | function_def | simple_decl | using_directive | water)*;
 
 using_directive: USING NAMESPACE identifier ';';
 
-function_decl: ('extern' | template_decl)? return_type? function_name function_param_list ctor_list? ';';
+function_decl: ('extern'? | template_decl*) return_type? function_name function_param_list ctor_list? ';';
 
-function_def: template_decl? return_type? function_name function_param_list ctor_list? compound_statement;
+function_def: template_decl* return_type? function_name function_param_list ctor_list? compound_statement;
 
 return_type : (function_decl_specifiers* type_name) ptr_operator*;
 
@@ -33,7 +33,7 @@ function_param_list : '(' parameter_decl_clause? ')' CV_QUALIFIER* exception_spe
 parameter_decl_clause: (parameter_decl (',' parameter_decl)*) (',' '...')?
                      | VOID;
 parameter_decl : param_decl_specifiers parameter_id;
-parameter_id: ptrs? ('(' parameter_id ')' | parameter_name) type_suffix?;
+parameter_id: (ptrs | rvalue_ref)? ('(' parameter_id ')' | parameter_name) type_suffix?;
 
 compound_statement: OPENING_CURLY { skipToEndOfObject(); };
 
@@ -73,7 +73,7 @@ simple_decl : storage_class_specifier* var_decl;
 storage_class_specifier: (EXTERN | TYPEDEF);
 
 var_decl : class_def init_declarator_list? #declByClass
-         | template_decl? type_name init_declarator_list #declByType
+         | template_decl* type_name init_declarator_list #declByType
          ;
 
 init_declarator_list: init_declarator (',' init_declarator)* ';';

--- a/src/main/antlr4/io/shiftleft/fuzzyc2cpg/Module.g4
+++ b/src/main/antlr4/io/shiftleft/fuzzyc2cpg/Module.g4
@@ -32,8 +32,10 @@ function_param_list : '(' parameter_decl_clause? ')' CV_QUALIFIER* exception_spe
 
 parameter_decl_clause: (parameter_decl (',' parameter_decl)*) (',' '...')?
                      | VOID;
-parameter_decl : param_decl_specifiers parameter_id;
-parameter_id: (ptrs | rvalue_ref)? ('(' parameter_id ')' | parameter_name) type_suffix?;
+parameter_ptrs: ptrs | rvalue_ref;
+parameter_decl: param_decl_specifiers parameter_id |
+                param_decl_specifiers parameter_ptrs?;
+parameter_id: parameter_ptrs? ('(' parameter_id ')' | parameter_name) type_suffix?;
 
 compound_statement: OPENING_CURLY { skipToEndOfObject(); };
 

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/parser/AstNodeFactory.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/parser/AstNodeFactory.java
@@ -88,12 +88,17 @@ public class AstNodeFactory {
     Parameter param = new Parameter();
 
     Parameter_declContext paramCtx = ctx;
-    Parameter_nameContext paramName = getNameOfParameter(paramCtx);
-
     Identifier name = new Identifier();
+
+    if (ctx.parameter_id() != null) {
+      Parameter_nameContext paramName = getNameOfParameter(paramCtx);
+      initializeFromContext(name, paramName);
+    } else {
+      name.setCodeStr("<anonymous>");
+    }
+
     ParameterType type = new ParameterType();
     initializeFromContext(type, ctx);
-    initializeFromContext(name, paramName);
     initializeFromContext(param, ctx);
 
     param.addChild(type);

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/parser/ModuleFunctionParserInterface.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/parser/ModuleFunctionParserInterface.java
@@ -28,8 +28,7 @@ public class ModuleFunctionParserInterface {
     try {
       driver.parseAndWalkString(text);
     } catch (RuntimeException ex) {
-      logger.info(ctx.function_name().getText() + " was skipped.");
-      //ex.printStackTrace();
+      logger.error(ctx.function_name().getText() + " was skipped."/*, ex*/);
     }
     CompoundStatement result = driver.getResult();
     Compound_statementContext statementContext = ctx.compound_statement();

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/parser/modules/CModuleParserTreeListener.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/parser/modules/CModuleParserTreeListener.java
@@ -112,10 +112,9 @@ public class CModuleParserTreeListener extends ModuleBaseListener {
 
   @Override
   public void enterTemplate_decl(ModuleParser.Template_declContext ctx) {
-    TemplateAstBuilder<?> builder = (TemplateAstBuilder<?>) p.builderStack.peek();
+    TemplateAstBuilder<?> builder = (TemplateAstBuilder) p.builderStack.peek();
     builder.setTemplateList(ctx);
   }
-
 
   @Override
   public void enterTemplate_name(ModuleParser.Template_nameContext ctx) {

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
@@ -175,7 +175,7 @@ class FuzzyC2Cpg(outputModuleFactory: CpgOutputModuleFactory) {
       case ex: RuntimeException => {
         logger.warn("Cannot parse module: " + filename + ", skipping")
         logger.warn("Complete exception: ", ex)
-        throw ex
+        return
       }
     }
 

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
@@ -175,7 +175,7 @@ class FuzzyC2Cpg(outputModuleFactory: CpgOutputModuleFactory) {
       case ex: RuntimeException => {
         logger.warn("Cannot parse module: " + filename + ", skipping")
         logger.warn("Complete exception: ", ex)
-        return
+        throw ex
       }
     }
 

--- a/src/test/java/io/shiftleft/fuzzyc2cpg/antlrparsers/moduleparser/FunctionParameterTests.java
+++ b/src/test/java/io/shiftleft/fuzzyc2cpg/antlrparsers/moduleparser/FunctionParameterTests.java
@@ -19,8 +19,8 @@ public class FunctionParameterTests extends ModuleParserTest {
 		ModuleParser parser = createParser(input);
 		String output = parser.function_def().toStringTree(parser);
 
-		assertTrue(output.startsWith(
-				"(function_def (return_type (type_name (base_type int))) (function_name (identifier foo)) (function_param_list ( (parameter_decl_clause (parameter_decl (param_decl_specifiers (type_name (base_type char))) (parameter_id (ptrs (ptr_operator *)) ( (parameter_id (ptrs (ptr_operator *)) (parameter_name (identifier param))) ) (type_suffix (param_type_list ( void )))))) )) (compound_statement { }))"));
+		assertEquals("(function_def (return_type (type_name (base_type int))) (function_name (identifier foo)) (function_param_list ( (parameter_decl_clause (parameter_decl (param_decl_specifiers (type_name (base_type char))) (parameter_id (parameter_ptrs (ptrs (ptr_operator *))) ( (parameter_id (parameter_ptrs (ptrs (ptr_operator *))) (parameter_name (identifier param))) ) (type_suffix (param_type_list ( void )))))) )) (compound_statement { }))",
+					 output);
 	}
 
 	@Test
@@ -78,7 +78,7 @@ public class FunctionParameterTests extends ModuleParserTest {
 		String input = "void foo(std::string&& s) {}";
 		ModuleParser parser = createParser(input);
 		String output = parser.function_def().toStringTree(parser);
-		assertEquals("(function_def (return_type (type_name (base_type void))) (function_name (identifier foo)) (function_param_list ( (parameter_decl_clause (parameter_decl (param_decl_specifiers (type_name (base_type std) :: (base_type string))) (parameter_id (rvalue_ref &&) (parameter_name (identifier s))))) )) (compound_statement { }))",
+		assertEquals("(function_def (return_type (type_name (base_type void))) (function_name (identifier foo)) (function_param_list ( (parameter_decl_clause (parameter_decl (param_decl_specifiers (type_name (base_type std) :: (base_type string))) (parameter_id (parameter_ptrs (rvalue_ref &&)) (parameter_name (identifier s))))) )) (compound_statement { }))",
 					 output);
 	}
 }

--- a/src/test/java/io/shiftleft/fuzzyc2cpg/antlrparsers/moduleparser/FunctionParameterTests.java
+++ b/src/test/java/io/shiftleft/fuzzyc2cpg/antlrparsers/moduleparser/FunctionParameterTests.java
@@ -1,13 +1,15 @@
 package io.shiftleft.fuzzyc2cpg.antlrparsers.moduleparser;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import io.shiftleft.fuzzyc2cpg.ModuleParser;
+
+import org.antlr.v4.runtime.tree.ParseTree;
 import org.junit.Test;
 
 
-public class FunctionParameterTests extends ModuleParserTest
-{
+public class FunctionParameterTests extends ModuleParserTest {
 
 	@Test
 	public void testFunctionPtrParam()
@@ -71,4 +73,12 @@ public class FunctionParameterTests extends ModuleParserTest
 		assertTrue(output.startsWith("(function_def"));
 	}
 
+	@Test
+	public void testMoveParameters() {
+		String input = "void foo(std::string&& s) {}";
+		ModuleParser parser = createParser(input);
+		String output = parser.function_def().toStringTree(parser);
+		assertEquals("(function_def (return_type (type_name (base_type void))) (function_name (identifier foo)) (function_param_list ( (parameter_decl_clause (parameter_decl (param_decl_specifiers (type_name (base_type std) :: (base_type string))) (parameter_id (rvalue_ref &&) (parameter_name (identifier s))))) )) (compound_statement { }))",
+					 output);
+	}
 }

--- a/src/test/java/io/shiftleft/fuzzyc2cpg/antlrparsers/moduleparser/TemplateTests.java
+++ b/src/test/java/io/shiftleft/fuzzyc2cpg/antlrparsers/moduleparser/TemplateTests.java
@@ -83,7 +83,6 @@ public class TemplateTests extends ModuleParserTest {
             output);
   }
 
-
   @Test
   public void testFunctionTemplate() {
     String input = "template <typename T> T foo(T t) {}";
@@ -159,6 +158,16 @@ public class TemplateTests extends ModuleParserTest {
   }
 
   @Test
+  public void testFunctionAnonParametersWithTemplate() {
+    String input = "template <typename A> A do_a(A) {}";
+    ModuleParser parser = createParser(input);
+    String output = parser.function_def().toStringTree(parser);
+
+    assertEquals("(function_def (template_decl template < (template_decl_param_list (template_decl_param (template_decl_keyword typename) (template_name A))) >) (return_type (type_name (base_type A))) (function_name (identifier do_a)) (function_param_list ( (parameter_decl_clause (parameter_decl (param_decl_specifiers (type_name (base_type A))))) )) (compound_statement { }))",
+            output);
+  }
+
+  @Test
   public void testFunctionDeclTemplate() {
     String input = "template <typename T> T foo(T t);";
     ModuleParser parser = createParser(input);
@@ -230,5 +239,15 @@ public class TemplateTests extends ModuleParserTest {
 
     assertEquals("(function_decl (template_decl template < (template_decl_param_list (template_decl_param (template_decl_keyword typename) (template_name A))) >) (template_decl template < (template_decl_param_list (template_decl_param (template_decl_keyword typename) (template_name B))) >) (return_type (type_name (base_type A))) (function_name (identifier do_a)) (function_param_list ( (parameter_decl_clause (parameter_decl (param_decl_specifiers (type_name (base_type B))) (parameter_id (parameter_name (identifier b))))) )) ;)",
                  output);
+  }
+
+  @Test
+  public void testFunctionDeclAnonParametersWithTemplate() {
+    String input = "template <typename A> A do_a(A);";
+    ModuleParser parser = createParser(input);
+    String output = parser.function_decl().toStringTree(parser);
+
+    assertEquals("(function_decl (template_decl template < (template_decl_param_list (template_decl_param (template_decl_keyword typename) (template_name A))) >) (return_type (type_name (base_type A))) (function_name (identifier do_a)) (function_param_list ( (parameter_decl_clause (parameter_decl (param_decl_specifiers (type_name (base_type A))))) )) ;)",
+            output);
   }
 }

--- a/src/test/java/io/shiftleft/fuzzyc2cpg/antlrparsers/moduleparser/TemplateTests.java
+++ b/src/test/java/io/shiftleft/fuzzyc2cpg/antlrparsers/moduleparser/TemplateTests.java
@@ -1,5 +1,6 @@
 package io.shiftleft.fuzzyc2cpg.antlrparsers.moduleparser;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
@@ -13,7 +14,8 @@ public class TemplateTests extends ModuleParserTest {
     String input = "template <typename T> class Foo {};";
     ModuleParser parser = createParser(input);
     String output = parser.class_def().toStringTree(parser);
-    assertTrue(output.contains("(class_def (template_decl template < (template_decl_param_list (template_decl_param (template_decl_keyword typename) (template_name T))) >) (class_key class) (class_name (identifier Foo)) { })"));
+    assertEquals("(class_def (template_decl template < (template_decl_param_list (template_decl_param (template_decl_keyword typename) (template_name T))) >) (class_key class) (class_name (identifier Foo)) { })",
+                 output);
   }
 
   @Test
@@ -21,7 +23,8 @@ public class TemplateTests extends ModuleParserTest {
     String input = "template <typename K, typename V> class Foo {};";
     ModuleParser parser = createParser(input);
     String output = parser.class_def().toStringTree(parser);
-    assertTrue(output.contains("(class_def (template_decl template < (template_decl_param_list (template_decl_param_list (template_decl_param (template_decl_keyword typename) (template_name K))) , (template_decl_param (template_decl_keyword typename) (template_name V))) >) (class_key class) (class_name (identifier Foo)) { })"));
+    assertEquals("(class_def (template_decl template < (template_decl_param_list (template_decl_param_list (template_decl_param (template_decl_keyword typename) (template_name K))) , (template_decl_param (template_decl_keyword typename) (template_name V))) >) (class_key class) (class_name (identifier Foo)) { })",
+                 output);
   }
 
   @Test
@@ -29,7 +32,8 @@ public class TemplateTests extends ModuleParserTest {
     String input = "template <template<typename, typename> typename M, typename K, typename V> class Foo {};";
     ModuleParser parser = createParser(input);
     String output = parser.class_def().toStringTree(parser);
-    assertTrue(output.contains("(class_def (template_decl template < (template_decl_param_list (template_decl_param_list (template_decl_param_list (template_template template < (template_decl_keyword typename) , (template_decl_keyword typename) >) (template_decl_keyword typename) (template_name M)) , (template_decl_param (template_decl_keyword typename) (template_name K))) , (template_decl_param (template_decl_keyword typename) (template_name V))) >) (class_key class) (class_name (identifier Foo)) { })"));
+    assertEquals("(class_def (template_decl template < (template_decl_param_list (template_decl_param_list (template_decl_param_list (template_template template < (template_decl_keyword typename) , (template_decl_keyword typename) >) (template_decl_keyword typename) (template_name M)) , (template_decl_param (template_decl_keyword typename) (template_name K))) , (template_decl_param (template_decl_keyword typename) (template_name V))) >) (class_key class) (class_name (identifier Foo)) { })",
+                 output);
   }
 
   @Test
@@ -37,7 +41,8 @@ public class TemplateTests extends ModuleParserTest {
     String input = "template <> class Foo<int> {};";
     ModuleParser parser = createParser(input);
     String output = parser.class_def().toStringTree(parser);
-    assertTrue(output.contains("(class_def (template_decl template < >) (class_key class) (class_name (identifier Foo)) (template_args < (template_args (base_type int)) >) { })"));
+    assertEquals("(class_def (template_decl template < >) (class_key class) (class_name (identifier Foo)) (template_args < (template_args (base_type int)) >) { })",
+                 output);
   }
 
   @Test
@@ -45,15 +50,47 @@ public class TemplateTests extends ModuleParserTest {
     String input = "template <typename Args...> class Foo {};";
     ModuleParser parser = createParser(input);
     String output = parser.class_def().toStringTree(parser);
-    assertTrue(output.contains("(class_def (template_decl template < (template_decl_param_list (template_decl_param (template_decl_keyword typename) (template_name Args ...))) >) (class_key class) (class_name (identifier Foo)) { })"));
+    assertEquals("(class_def (template_decl template < (template_decl_param_list (template_decl_param (template_decl_keyword typename) (template_name Args ...))) >) (class_key class) (class_name (identifier Foo)) { })",
+                 output);
   }
+
+  @Test
+  public void testClassTemplateOverload() {
+    String input = "template <typename A, bool B> class Foo {};";
+    ModuleParser parser = createParser(input);
+    String output = parser.class_def().toStringTree(parser);
+    assertEquals("(class_def (template_decl template < (template_decl_param_list (template_decl_param_list (template_decl_param (template_decl_keyword typename) (template_name A))) , (template_decl_param (identifier bool) (template_name B))) >) (class_key class) (class_name (identifier Foo)) { })",
+                 output);
+  }
+
+  @Test
+  public void testClassConstTemplate() {
+    String input = "class Foo : public Bar<const Baz> {};";
+    ModuleParser parser = createParser(input);
+    String output = parser.class_def().toStringTree(parser);
+
+    assertEquals("(class_def (class_key class) (class_name (identifier Foo)) (base_classes : (base_class (access_specifier public) (identifier Bar) (template_args < (template_args const (base_type Baz)) >))) { })",
+                 output);
+  }
+
+  @Test
+  public void testClassDoubleTemplate() {
+    String input = "template <typename A> template <typename B> class Foo {};";
+    ModuleParser parser = createParser(input);
+    String output = parser.class_def().toStringTree(parser);
+
+    assertEquals("(class_def (template_decl template < (template_decl_param_list (template_decl_param (template_decl_keyword typename) (template_name A))) >) (template_decl template < (template_decl_param_list (template_decl_param (template_decl_keyword typename) (template_name B))) >) (class_key class) (class_name (identifier Foo)) { })",
+            output);
+  }
+
 
   @Test
   public void testFunctionTemplate() {
     String input = "template <typename T> T foo(T t) {}";
     ModuleParser parser = createParser(input);
     String output = parser.function_def().toStringTree(parser);
-    assertTrue(output.contains("(function_def (template_decl template < (template_decl_param_list (template_decl_param (template_decl_keyword typename) (template_name T))) >) (return_type (type_name (base_type T))) (function_name (identifier foo)) (function_param_list ( (parameter_decl_clause (parameter_decl (param_decl_specifiers (type_name (base_type T))) (parameter_id (parameter_name (identifier t))))) )) (compound_statement { }))"));
+    assertEquals("(function_def (template_decl template < (template_decl_param_list (template_decl_param (template_decl_keyword typename) (template_name T))) >) (return_type (type_name (base_type T))) (function_name (identifier foo)) (function_param_list ( (parameter_decl_clause (parameter_decl (param_decl_specifiers (type_name (base_type T))) (parameter_id (parameter_name (identifier t))))) )) (compound_statement { }))",
+                 output);
   }
 
   @Test
@@ -61,7 +98,8 @@ public class TemplateTests extends ModuleParserTest {
     String input = "template <typename K, typename V> V foo(K k) {}";
     ModuleParser parser = createParser(input);
     String output = parser.function_def().toStringTree(parser);
-    assertTrue(output.contains("(function_def (template_decl template < (template_decl_param_list (template_decl_param_list (template_decl_param (template_decl_keyword typename) (template_name K))) , (template_decl_param (template_decl_keyword typename) (template_name V))) >) (return_type (type_name (base_type V))) (function_name (identifier foo)) (function_param_list ( (parameter_decl_clause (parameter_decl (param_decl_specifiers (type_name (base_type K))) (parameter_id (parameter_name (identifier k))))) )) (compound_statement { }))") );
+    assertEquals("(function_def (template_decl template < (template_decl_param_list (template_decl_param_list (template_decl_param (template_decl_keyword typename) (template_name K))) , (template_decl_param (template_decl_keyword typename) (template_name V))) >) (return_type (type_name (base_type V))) (function_name (identifier foo)) (function_param_list ( (parameter_decl_clause (parameter_decl (param_decl_specifiers (type_name (base_type K))) (parameter_id (parameter_name (identifier k))))) )) (compound_statement { }))",
+                 output);
   }
 
   @Test
@@ -69,7 +107,8 @@ public class TemplateTests extends ModuleParserTest {
     String input = "template <template <typename, typename> typename M, typename K, typename V> M<K, V> foo(M<K, V> k) {}";
     ModuleParser parser = createParser(input);
     String output = parser.function_def().toStringTree(parser);
-    assertTrue(output.contains("(function_def (template_decl template < (template_decl_param_list (template_decl_param_list (template_decl_param_list (template_template template < (template_decl_keyword typename) , (template_decl_keyword typename) >) (template_decl_keyword typename) (template_name M)) , (template_decl_param (template_decl_keyword typename) (template_name K))) , (template_decl_param (template_decl_keyword typename) (template_name V))) >) (return_type (type_name (base_type M) < (template_args (base_type K) , (base_type V)) >)) (function_name (identifier foo)) (function_param_list ( (parameter_decl_clause (parameter_decl (param_decl_specifiers (type_name (base_type M) < (template_args (base_type K) , (base_type V)) >)) (parameter_id (parameter_name (identifier k))))) )) (compound_statement { }))"));
+    assertEquals("(function_def (template_decl template < (template_decl_param_list (template_decl_param_list (template_decl_param_list (template_template template < (template_decl_keyword typename) , (template_decl_keyword typename) >) (template_decl_keyword typename) (template_name M)) , (template_decl_param (template_decl_keyword typename) (template_name K))) , (template_decl_param (template_decl_keyword typename) (template_name V))) >) (return_type (type_name (base_type M) < (template_args (base_type K) , (base_type V)) >)) (function_name (identifier foo)) (function_param_list ( (parameter_decl_clause (parameter_decl (param_decl_specifiers (type_name (base_type M) < (template_args (base_type K) , (base_type V)) >)) (parameter_id (parameter_name (identifier k))))) )) (compound_statement { }))",
+                 output);
   }
 
   @Test
@@ -77,7 +116,8 @@ public class TemplateTests extends ModuleParserTest {
     String input = "template <> int foo(int y) {}";
     ModuleParser parser = createParser(input);
     String output = parser.function_def().toStringTree(parser);
-    assertTrue(output.contains("(function_def (template_decl template < >) (return_type (type_name (base_type int))) (function_name (identifier foo)) (function_param_list ( (parameter_decl_clause (parameter_decl (param_decl_specifiers (type_name (base_type int))) (parameter_id (parameter_name (identifier y))))) )) (compound_statement { }))"));
+    assertEquals("(function_def (template_decl template < >) (return_type (type_name (base_type int))) (function_name (identifier foo)) (function_param_list ( (parameter_decl_clause (parameter_decl (param_decl_specifiers (type_name (base_type int))) (parameter_id (parameter_name (identifier y))))) )) (compound_statement { }))",
+                 output);
   }
 
   @Test
@@ -85,7 +125,37 @@ public class TemplateTests extends ModuleParserTest {
     String input = "template <typename Args...> int Foo(Args... args) {};";
     ModuleParser parser = createParser(input);
     String output = parser.function_def().toStringTree(parser);
-    assertTrue(output.contains("(function_def (template_decl template < (template_decl_param_list (template_decl_param (template_decl_keyword typename) (template_name Args ...))) >) (return_type (type_name (base_type int))) (function_name (identifier Foo)) (function_param_list ( (parameter_decl_clause (parameter_decl (param_decl_specifiers (type_name (base_type Args))) (parameter_id ... (parameter_name (identifier args))))) )) (compound_statement { }))"));
+    assertEquals("(function_def (template_decl template < (template_decl_param_list (template_decl_param (template_decl_keyword typename) (template_name Args ...))) >) (return_type (type_name (base_type int))) (function_name (identifier Foo)) (function_param_list ( (parameter_decl_clause (parameter_decl (param_decl_specifiers (type_name (base_type Args ...))) (parameter_id (parameter_name (identifier args))))) )) (compound_statement { }))",
+                 output);
+  }
+
+  @Test
+  public void testFunctionTemplateOverload() {
+    String input = "template <typename A, bool B> A Foo(B b) {};";
+    ModuleParser parser = createParser(input);
+    String output = parser.function_def().toStringTree(parser);
+    assertEquals("(function_def (template_decl template < (template_decl_param_list (template_decl_param_list (template_decl_param (template_decl_keyword typename) (template_name A))) , (template_decl_param (identifier bool) (template_name B))) >) (return_type (type_name (base_type A))) (function_name (identifier Foo)) (function_param_list ( (parameter_decl_clause (parameter_decl (param_decl_specifiers (type_name (base_type B))) (parameter_id (parameter_name (identifier b))))) )) (compound_statement { }))",
+            output);
+  }
+
+  @Test
+  public void testFunctionConstTemplate() {
+    String input = "void foo(Foo<const Bar> foo) {}";
+    ModuleParser parser = createParser(input);
+    String output = parser.function_def().toStringTree(parser);
+
+    assertEquals("(function_def (return_type (type_name (base_type void))) (function_name (identifier foo)) (function_param_list ( (parameter_decl_clause (parameter_decl (param_decl_specifiers (type_name (base_type Foo) < (template_args const (base_type Bar)) >)) (parameter_id (parameter_name (identifier foo))))) )) (compound_statement { }))",
+                 output);
+  }
+
+  @Test
+  public void testFunctionDoubleTemplate() {
+    String input = "template <typename A> template <typename B> A do_a(B b) {}";
+    ModuleParser parser = createParser(input);
+    String output = parser.function_def().toStringTree(parser);
+
+    assertEquals("(function_def (template_decl template < (template_decl_param_list (template_decl_param (template_decl_keyword typename) (template_name A))) >) (template_decl template < (template_decl_param_list (template_decl_param (template_decl_keyword typename) (template_name B))) >) (return_type (type_name (base_type A))) (function_name (identifier do_a)) (function_param_list ( (parameter_decl_clause (parameter_decl (param_decl_specifiers (type_name (base_type B))) (parameter_id (parameter_name (identifier b))))) )) (compound_statement { }))",
+            output);
   }
 
   @Test
@@ -93,7 +163,8 @@ public class TemplateTests extends ModuleParserTest {
     String input = "template <typename T> T foo(T t);";
     ModuleParser parser = createParser(input);
     String output = parser.function_decl().toStringTree(parser);
-    assertTrue(output.contains("(function_decl (template_decl template < (template_decl_param_list (template_decl_param (template_decl_keyword typename) (template_name T))) >) (return_type (type_name (base_type T))) (function_name (identifier foo)) (function_param_list ( (parameter_decl_clause (parameter_decl (param_decl_specifiers (type_name (base_type T))) (parameter_id (parameter_name (identifier t))))) )) ;)"));
+    assertEquals("(function_decl (template_decl template < (template_decl_param_list (template_decl_param (template_decl_keyword typename) (template_name T))) >) (return_type (type_name (base_type T))) (function_name (identifier foo)) (function_param_list ( (parameter_decl_clause (parameter_decl (param_decl_specifiers (type_name (base_type T))) (parameter_id (parameter_name (identifier t))))) )) ;)",
+                 output);
   }
 
   @Test
@@ -101,7 +172,8 @@ public class TemplateTests extends ModuleParserTest {
     String input = "template <typename K, typename V> V foo(K k);";
     ModuleParser parser = createParser(input);
     String output = parser.function_decl().toStringTree(parser);
-    assertTrue(output.contains("(function_decl (template_decl template < (template_decl_param_list (template_decl_param_list (template_decl_param (template_decl_keyword typename) (template_name K))) , (template_decl_param (template_decl_keyword typename) (template_name V))) >) (return_type (type_name (base_type V))) (function_name (identifier foo)) (function_param_list ( (parameter_decl_clause (parameter_decl (param_decl_specifiers (type_name (base_type K))) (parameter_id (parameter_name (identifier k))))) )) ;)") );
+    assertEquals("(function_decl (template_decl template < (template_decl_param_list (template_decl_param_list (template_decl_param (template_decl_keyword typename) (template_name K))) , (template_decl_param (template_decl_keyword typename) (template_name V))) >) (return_type (type_name (base_type V))) (function_name (identifier foo)) (function_param_list ( (parameter_decl_clause (parameter_decl (param_decl_specifiers (type_name (base_type K))) (parameter_id (parameter_name (identifier k))))) )) ;)",
+                 output);
   }
 
   @Test
@@ -109,7 +181,8 @@ public class TemplateTests extends ModuleParserTest {
     String input = "template <template <typename, typename> typename M, typename K, typename V> M<K, V> foo(M<K, V> k);";
     ModuleParser parser = createParser(input);
     String output = parser.function_decl().toStringTree(parser);
-    assertTrue(output.contains("(function_decl (template_decl template < (template_decl_param_list (template_decl_param_list (template_decl_param_list (template_template template < (template_decl_keyword typename) , (template_decl_keyword typename) >) (template_decl_keyword typename) (template_name M)) , (template_decl_param (template_decl_keyword typename) (template_name K))) , (template_decl_param (template_decl_keyword typename) (template_name V))) >) (return_type (type_name (base_type M) < (template_args (base_type K) , (base_type V)) >)) (function_name (identifier foo)) (function_param_list ( (parameter_decl_clause (parameter_decl (param_decl_specifiers (type_name (base_type M) < (template_args (base_type K) , (base_type V)) >)) (parameter_id (parameter_name (identifier k))))) )) ;)"));
+    assertEquals("(function_decl (template_decl template < (template_decl_param_list (template_decl_param_list (template_decl_param_list (template_template template < (template_decl_keyword typename) , (template_decl_keyword typename) >) (template_decl_keyword typename) (template_name M)) , (template_decl_param (template_decl_keyword typename) (template_name K))) , (template_decl_param (template_decl_keyword typename) (template_name V))) >) (return_type (type_name (base_type M) < (template_args (base_type K) , (base_type V)) >)) (function_name (identifier foo)) (function_param_list ( (parameter_decl_clause (parameter_decl (param_decl_specifiers (type_name (base_type M) < (template_args (base_type K) , (base_type V)) >)) (parameter_id (parameter_name (identifier k))))) )) ;)",
+                 output);
   }
 
   @Test
@@ -117,14 +190,45 @@ public class TemplateTests extends ModuleParserTest {
     String input = "template <> int foo(int y);";
     ModuleParser parser = createParser(input);
     String output = parser.function_decl().toStringTree(parser);
-    assertTrue(output.contains("(function_decl (template_decl template < >) (return_type (type_name (base_type int))) (function_name (identifier foo)) (function_param_list ( (parameter_decl_clause (parameter_decl (param_decl_specifiers (type_name (base_type int))) (parameter_id (parameter_name (identifier y))))) )) ;)"));
+    assertEquals("(function_decl (template_decl template < >) (return_type (type_name (base_type int))) (function_name (identifier foo)) (function_param_list ( (parameter_decl_clause (parameter_decl (param_decl_specifiers (type_name (base_type int))) (parameter_id (parameter_name (identifier y))))) )) ;)",
+                 output);
   }
 
   @Test
   public void testVariadicFunctionDeclTemplate() {
-    String input = "template <typename Args...> int Foo(Args... args) {};";
+    String input = "template <typename Args...> int Foo(Args... args);";
     ModuleParser parser = createParser(input);
     String output = parser.function_decl().toStringTree(parser);
-    assertTrue(output.contains("(function_decl (template_decl template < (template_decl_param_list (template_decl_param (template_decl_keyword typename) (template_name Args ...))) >) (return_type (type_name (base_type int))) (function_name (identifier Foo)) (function_param_list ( (parameter_decl_clause (parameter_decl (param_decl_specifiers (type_name (base_type Args))) (parameter_id ... (parameter_name (identifier args))))) )) { } ;)"));
+    assertEquals("(function_decl (template_decl template < (template_decl_param_list (template_decl_param (template_decl_keyword typename) (template_name Args ...))) >) (return_type (type_name (base_type int))) (function_name (identifier Foo)) (function_param_list ( (parameter_decl_clause (parameter_decl (param_decl_specifiers (type_name (base_type Args ...))) (parameter_id (parameter_name (identifier args))))) )) ;)",
+                 output);
+  }
+
+  @Test
+  public void testFunctionDeclTemplateOverload() {
+    String input = "template <typename A, bool B> A Foo(B b);";
+    ModuleParser parser = createParser(input);
+    String output = parser.function_decl().toStringTree(parser);
+    assertEquals("(function_decl (template_decl template < (template_decl_param_list (template_decl_param_list (template_decl_param (template_decl_keyword typename) (template_name A))) , (template_decl_param (identifier bool) (template_name B))) >) (return_type (type_name (base_type A))) (function_name (identifier Foo)) (function_param_list ( (parameter_decl_clause (parameter_decl (param_decl_specifiers (type_name (base_type B))) (parameter_id (parameter_name (identifier b))))) )) ;)",
+            output);
+  }
+
+  @Test
+  public void testFunctionDeclConstTemplate() {
+    String input = "void process_foo(Foo<const Bar> foo);";
+    ModuleParser parser = createParser(input);
+    String output = parser.function_decl().toStringTree(parser);
+
+    assertEquals("(function_decl (return_type (type_name (base_type void))) (function_name (identifier process_foo)) (function_param_list ( (parameter_decl_clause (parameter_decl (param_decl_specifiers (type_name (base_type Foo) < (template_args const (base_type Bar)) >)) (parameter_id (parameter_name (identifier foo))))) )) ;)",
+                 output);
+  }
+
+  @Test
+  public void testFunctionDeclDoubleTemplate() {
+    String input = "template <typename A> template <typename B> A do_a(B b);";
+    ModuleParser parser = createParser(input);
+    String output = parser.function_decl().toStringTree(parser);
+
+    assertEquals("(function_decl (template_decl template < (template_decl_param_list (template_decl_param (template_decl_keyword typename) (template_name A))) >) (template_decl template < (template_decl_param_list (template_decl_param (template_decl_keyword typename) (template_name B))) >) (return_type (type_name (base_type A))) (function_name (identifier do_a)) (function_param_list ( (parameter_decl_clause (parameter_decl (param_decl_specifiers (type_name (base_type B))) (parameter_id (parameter_name (identifier b))))) )) ;)",
+                 output);
   }
 }

--- a/src/test/java/io/shiftleft/fuzzyc2cpg/parsetreetoast/ModuleBuildersTest.java
+++ b/src/test/java/io/shiftleft/fuzzyc2cpg/parsetreetoast/ModuleBuildersTest.java
@@ -1,8 +1,5 @@
 package io.shiftleft.fuzzyc2cpg.parsetreetoast;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import java.util.List;
 
 import org.antlr.v4.runtime.CharStream;
@@ -13,15 +10,15 @@ import io.shiftleft.fuzzyc2cpg.ModuleLexer;
 import io.shiftleft.fuzzyc2cpg.ast.AstNode;
 import io.shiftleft.fuzzyc2cpg.ast.declarations.ClassDefStatement;
 import io.shiftleft.fuzzyc2cpg.ast.declarations.IdentifierDecl;
-import io.shiftleft.fuzzyc2cpg.ast.functionDef.FunctionDefBase;
-import io.shiftleft.fuzzyc2cpg.ast.functionDef.ParameterBase;
-import io.shiftleft.fuzzyc2cpg.ast.functionDef.Template;
-import io.shiftleft.fuzzyc2cpg.ast.functionDef.TemplateParameterList;
+import io.shiftleft.fuzzyc2cpg.ast.functionDef.*;
 import io.shiftleft.fuzzyc2cpg.ast.langc.functiondef.FunctionDef;
+import io.shiftleft.fuzzyc2cpg.ast.langc.functiondef.Parameter;
 import io.shiftleft.fuzzyc2cpg.ast.langc.functiondef.ParameterType;
 import io.shiftleft.fuzzyc2cpg.ast.statements.IdentifierDeclStatement;
 import io.shiftleft.fuzzyc2cpg.parser.TokenSubStream;
 import io.shiftleft.fuzzyc2cpg.parser.modules.AntlrCModuleParserDriver;
+
+import static org.junit.Assert.*;
 
 public class ModuleBuildersTest
 {
@@ -310,14 +307,111 @@ public class ModuleBuildersTest
 		assertEquals("Z", secondTemplate.getName());
 	}
 
+	// Test for https://github.com/ShiftLeftSecurity/joern/issues/126
+	@Test
+	public void testFunctionWithAnonParameter() {
+		String input = "template <class C> C foo(C) {}";
+		List<AstNode> codeItems = parseInput(input);
+		FunctionDef functionDef = (FunctionDef) codeItems.get(0);
+		ParameterList parameters = functionDef.getParameterList();
+		TemplateParameterList templates = functionDef.getTemplateParameterList();
+
+		assertEquals(1, parameters.size());
+		Parameter param = (Parameter) parameters.getChild(0);
+		assertEquals("<anonymous>", param.getName());
+		assertEquals("C", param.getType().getEscapedCodeStr());
+
+		assertEquals("foo", functionDef.getIdentifier().getEscapedCodeStr());
+		assertEquals(1, templates.size());
+		assertEquals(1, templates.getChildCount());
+
+		Template firstTemplate = (Template) templates.getChild(0);
+		assertEquals(1, firstTemplate.getChildCount());
+		assertEquals("C", firstTemplate.getName());
+	}
+
+	@Test
+	public void testFunctionWithAnonRefParameter() {
+		String input = "template <class C> C foo(C&) {}";
+		List<AstNode> codeItems = parseInput(input);
+		FunctionDef functionDef = (FunctionDef) codeItems.get(0);
+		ParameterList parameters = functionDef.getParameterList();
+		TemplateParameterList templates = functionDef.getTemplateParameterList();
+
+		assertEquals(1, parameters.size());
+		Parameter param = (Parameter) parameters.getChild(0);
+		assertEquals("<anonymous>", param.getName());
+		assertEquals("C &", param.getType().getEscapedCodeStr());
+
+		assertEquals("foo", functionDef.getIdentifier().getEscapedCodeStr());
+		assertEquals(1, templates.size());
+		assertEquals(1, templates.getChildCount());
+
+		Template firstTemplate = (Template) templates.getChild(0);
+		assertEquals(1, firstTemplate.getChildCount());
+		assertEquals("C", firstTemplate.getName());
+	}
+
+	// Test for https://github.com/ShiftLeftSecurity/joern/issues/126
+	@Test
+	public void testFunctionDeclWithAnonParameter() {
+		String input = "template <class C> C foo(C);";
+		List<AstNode> codeItems = parseInput(input);
+		FunctionDef functionDef = (FunctionDef) codeItems.get(0);
+		ParameterList parameters = functionDef.getParameterList();
+		TemplateParameterList templates = functionDef.getTemplateParameterList();
+
+		assertEquals(1, parameters.size());
+		Parameter param = (Parameter) parameters.getChild(0);
+		assertEquals("<anonymous>", param.getName());
+		assertEquals("C", param.getType().getEscapedCodeStr());
+
+		assertEquals("foo", functionDef.getIdentifier().getEscapedCodeStr());
+		assertEquals(1, templates.size());
+		assertEquals(1, templates.getChildCount());
+
+		Template firstTemplate = (Template) templates.getChild(0);
+		assertEquals(1, firstTemplate.getChildCount());
+		assertEquals("C", firstTemplate.getName());
+	}
+
+	@Test
+	public void testFunctionDeclWithAnonRefParameter() {
+		String input = "template <class C> C foo(C&);";
+		List<AstNode> codeItems = parseInput(input);
+		FunctionDef functionDef = (FunctionDef) codeItems.get(0);
+		ParameterList parameters = functionDef.getParameterList();
+		TemplateParameterList templates = functionDef.getTemplateParameterList();
+
+		assertEquals(1, parameters.size());
+		Parameter param = (Parameter) parameters.getChild(0);
+		assertEquals("<anonymous>", param.getName());
+		assertEquals("C &", param.getType().getEscapedCodeStr());
+
+		assertEquals("foo", functionDef.getIdentifier().getEscapedCodeStr());
+		assertEquals(1, templates.size());
+		assertEquals(1, templates.getChildCount());
+
+		Template firstTemplate = (Template) templates.getChild(0);
+		assertEquals(1, firstTemplate.getChildCount());
+		assertEquals("C", firstTemplate.getName());
+	}
+
 	@Test
 	public void testTemplateAssociationWithFunctionDecl() {
 		String input = "template <typename T, typename Z> T foo(T x);";
 		List<AstNode> codeItems = parseInput(input);
 		FunctionDef functionDef = (FunctionDef) codeItems.get(0);
-		TemplateParameterList templates = (TemplateParameterList) functionDef.getChild(1);
+		ParameterList parameters = functionDef.getParameterList();
+		TemplateParameterList templates = functionDef.getTemplateParameterList();
 
 		assertEquals("foo", functionDef.getIdentifier().getEscapedCodeStr());
+
+		assertEquals(1, parameters.size());
+		Parameter param = (Parameter) parameters.getChild(0);
+		assertEquals("x", param.getName());
+		assertEquals("T", param.getType().getEscapedCodeStr());
+
 		assertEquals(2, templates.size());
 		assertEquals(2, templates.getChildCount());
 

--- a/src/test/scala/io/shiftleft/fuzzyc2cpg/cfg/AstToCfgTests.scala
+++ b/src/test/scala/io/shiftleft/fuzzyc2cpg/cfg/AstToCfgTests.scala
@@ -165,6 +165,7 @@ class AstToCfgTests extends WordSpec with Matchers {
       }
 
     "be correct for short-circuit AND expression" in
+      // TODO: Broken by supporting move params?
       new Fixture("x && y;") {
         succOf("ENTRY") shouldBe expected(("x", AlwaysEdge))
         succOf("x") shouldBe expected(("y", TrueEdge), ("x && y", FalseEdge))


### PR DESCRIPTION
- Support anonymous parameters.
- Support parameter packs in parameter lists.
- Support move parameters e.g. `Foo&& foo`.
- Support `const` & `volatile` template arguments
- Support multiple template definitions e.g. `template<class A> template<class B> void foo(...)`

In addition to unit tests, I also ran Joern on some test code to ensure that the output CPG is what we expect. See the example below, note the `name` and `typeFullName` fields, which show anonymous and move parameter fixes working as intended.

```scala
 MethodParameterIn(
    id -> 72L,
    code -> "T&&",
    order -> 2,
    name -> "<anonymous>",
    evaluationStrategy -> "BY_VALUE",
    typeFullName -> "T &&",
    dynamicTypeHintFullName -> List(),
    lineNumber -> Some(40),
    columnNumber -> Some(14)
  )
```

This PR doesn't fix _all_ the exceptions thrown by the Blender source. I will look into fixing these next.