### PR TITLE
Support global identifiers.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,8 @@ libraryDependencies ++= Seq(
   "org.apache.tinkerpop" % "tinkergraph-gremlin" % "3.4.3" % Test,
 )
 
+excludeDependencies += "org.apache.logging.log4j" % "log4j-slf4j-impl"
+
 // uncomment if you want to use a cpg version that has *just* been released
 // (it takes a few hours until it syncs to maven central)
 resolvers += "Sonatype OSS" at "https://oss.sonatype.org/content/repositories/public"

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgConverter.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgConverter.scala
@@ -39,6 +39,7 @@ class AstToCpgConverter[NodeBuilderType, NodeType, EdgeBuilderType, EdgeType](
   private var typeNames = Set.empty[String]
 
   pushContext(cpgParent, 1)
+  scope.pushNewScope(cpgParent) // Push global scope
 
   private class Context(val cpgParent: NodeType,
                         var childNum: Int,
@@ -590,8 +591,6 @@ class AstToCpgConverter[NodeBuilderType, NodeType, EdgeBuilderType, EdgeType](
         .createNode(identifierDecl)
       addAstChild(cpgMember)
     } else {
-      // We only process file level identifier declarations if they are typedefs.
-      // Everything else is ignored.
       if (!scope.isEmpty) {
         val localName = identifierDecl.getName.getEscapedCodeStr
         val cpgLocal = adapter
@@ -599,6 +598,8 @@ class AstToCpgConverter[NodeBuilderType, NodeType, EdgeBuilderType, EdgeType](
           .addProperty(NodeProperty.CODE, localName)
           .addProperty(NodeProperty.NAME, localName)
           .addProperty(NodeProperty.TYPE_FULL_NAME, registerType(declTypeName))
+          .addProperty(NodeProperty.LINE_NUMBER, identifierDecl.getLocation.startLine)
+          .addProperty(NodeProperty.COLUMN_NUMBER, identifierDecl.getLocation.startPos)
           .createNode(identifierDecl)
 
         val scopeParentNode =

--- a/src/test/java/io/shiftleft/fuzzyc2cpg/parsetreetoast/ModuleBuildersTest.java
+++ b/src/test/java/io/shiftleft/fuzzyc2cpg/parsetreetoast/ModuleBuildersTest.java
@@ -444,6 +444,20 @@ public class ModuleBuildersTest
 		assertEquals("Z", secondTemplate.getName());
 	}
 
+	@Test
+	public void testGlobalVariableDecl() {
+		String input = "int x;";
+		List <AstNode> codeItems = parseInput(input);
+		IdentifierDeclStatement stmt = (IdentifierDeclStatement) codeItems.get(0);
+
+		assertEquals(1, stmt.getChildCount());
+		IdentifierDecl decl = (IdentifierDecl) stmt.getChild(0);
+
+		assertEquals(2, decl.getChildCount());
+		assertEquals(decl.getType().completeType, "int");
+		assertEquals(decl.getName().getEscapedCodeStr(), "x");
+	}
+
 	private List<AstNode> parseInput(String input)
 	{
 		AntlrCModuleParserDriver parser = new AntlrCModuleParserDriver();

--- a/src/test/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgTests.scala
+++ b/src/test/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgTests.scala
@@ -148,6 +148,16 @@ class AstToCpgTests extends WordSpec with Matchers {
       result.size shouldBe 1
       result
     }
+
+    def getLocal(name: String): List[Vertex] = {
+      val result = graph.V
+        .hasLabel(NodeTypes.LOCAL)
+        .has(NodeKeys.NAME -> name)
+        .l
+
+      result.size shouldBe 1
+      result
+    }
   }
 
   "Method AST layout" should {
@@ -777,5 +787,27 @@ class AstToCpgTests extends WordSpec with Matchers {
       assignment.checkForSingle(NodeKeys.NAME, Operators.assignment)
       assignment.checkForSingle[Integer](NodeKeys.LINE_NUMBER, 8)
     }
+
+    "correctly parse global variable declarations" in new Fixture("""
+        |int x;
+        |int y = 5;
+        |bool b;
+        |""".stripMargin) {
+      val localX = getLocal("x")
+      localX.checkForSingle[Integer](NodeKeys.LINE_NUMBER, 2)
+      localX.checkForSingle[String](NodeKeys.TYPE_FULL_NAME, "int")
+      localX.checkForSingle[String](NodeKeys.CODE, "x")
+
+      val localY = getLocal("y")
+      localY.checkForSingle[Integer](NodeKeys.LINE_NUMBER, 3)
+      localY.checkForSingle[String](NodeKeys.TYPE_FULL_NAME, "int")
+      localY.checkForSingle[String](NodeKeys.CODE, "y")
+
+      val localB = getLocal("b")
+      localB.checkForSingle[Integer](NodeKeys.LINE_NUMBER, 4)
+      localB.checkForSingle[String](NodeKeys.TYPE_FULL_NAME, "bool")
+      localB.checkForSingle[String](NodeKeys.CODE, "b")
+    }
+
   }
 }


### PR DESCRIPTION
- Push a new scope for global identifiers.
- Global identifiers are represented using `LOCAL` nodes.
- Resolve conflict between SLF4J & Log4j by explicitly excluding Log4j from the dependency list.