### PR TITLE
Do not relativize paths before handing to preprocessor.

### DIFF
--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
@@ -67,7 +67,8 @@ class FuzzyC2Cpg(outputModuleFactory: CpgOutputModuleFactory) {
       logger.info(s"Preprocessing complete, files written to [$preprocessedPath], starting CPG generation...")
       runAndOutput(Set(preprocessedPath.toString), sourceFileExtensions)
     } else {
-      logger.error(s"Error occurred whilst running preprocessor. Log written to [$preprocessorLogFile]. Exit code [$exitCode].")
+      logger.error(
+        s"Error occurred whilst running preprocessor. Log written to [$preprocessorLogFile]. Exit code [$exitCode].")
     }
   }
 

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
@@ -15,6 +15,7 @@ import io.shiftleft.proto.cpg.Cpg.{CpgStruct, NodePropertyName}
 import java.nio.file.{Files, Path}
 
 import scala.collection.mutable
+import scala.collection.mutable.ListBuffer
 import scala.util.control.NonFatal
 
 class FuzzyC2Cpg(outputModuleFactory: CpgOutputModuleFactory) {
@@ -43,22 +44,15 @@ class FuzzyC2Cpg(outputModuleFactory: CpgOutputModuleFactory) {
 
     val sourceFileNames = SourceFiles.determine(sourcePaths, sourceFileExtensions)
 
-    val cmd = Seq(
-      preprocessorExecutable,
-      "--verbose",
-      "-o",
-      preprocessedPath.toString,
-      "-f",
-      sourceFileNames.mkString(","),
-      "--include",
-      includeFiles.mkString(","),
-      "-I",
-      includePaths.mkString(","),
-      "-D",
-      defines.mkString(","),
-      "-U",
-      undefines.mkString(",")
-    )
+    val commandBuffer = new ListBuffer[String]()
+    commandBuffer.append(preprocessorExecutable, "--verbose", "-o", preprocessedPath.toString)
+    if (sourceFileNames.nonEmpty) commandBuffer.append("-f", sourceFileNames.mkString(","))
+    if (includeFiles.nonEmpty) commandBuffer.append("--include", includeFiles.mkString(","))
+    if (includePaths.nonEmpty) commandBuffer.append("-I", includePaths.mkString(","))
+    if (defines.nonEmpty) commandBuffer.append("-D", defines.mkString(","))
+    if (undefines.nonEmpty) commandBuffer.append("-U", defines.mkString(","))
+
+    val cmd = commandBuffer.toList
 
     // Run preprocessor
     logger.info("Running preprocessor...")
@@ -70,10 +64,10 @@ class FuzzyC2Cpg(outputModuleFactory: CpgOutputModuleFactory) {
     val exitCode = process.waitFor()
 
     if (exitCode == 0) {
-      logger.info("Preprocessing complete, starting CPG generation...")
+      logger.info(s"Preprocessing complete, files written to [$preprocessedPath], starting CPG generation...")
       runAndOutput(Set(preprocessedPath.toString), sourceFileExtensions)
     } else {
-      logger.error(s"Error occurred whilst running preprocessor. Exit code [$exitCode].")
+      logger.error(s"Error occurred whilst running preprocessor. Log written to [$preprocessorLogFile]. Exit code [$exitCode].")
     }
   }
 

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/SourceFiles.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/SourceFiles.scala
@@ -19,7 +19,7 @@ object SourceFiles {
     val matchingFiles = files.filter(hasSourceFileExtension).map(_.toString)
     val matchingFilesFromDirs = dirs
       .flatMap(_.listRecursively.filter(hasSourceFileExtension))
-      .map(File(".").path.relativize(_).toString)
+      .map(_.toString)
 
     matchingFiles ++ matchingFilesFromDirs
   }


### PR DESCRIPTION
- Preserve path format as-is when handing to the preprocessor.
- Remove any preprocessor flags with empty arguments.