### PR TITLE
Fix emojis causing havoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ private-key.pem
 
 cpg.bin.zip
 
+## Bloop ##
+.bloop/
+
 # Created by https://www.gitignore.io/api/c++,cmake,linux
 # Edit at https://www.gitignore.io/?templates=c++,cmake,linux
 

--- a/src/main/antlr4/io/shiftleft/fuzzyc2cpg/Common.g4
+++ b/src/main/antlr4/io/shiftleft/fuzzyc2cpg/Common.g4
@@ -2,72 +2,43 @@ grammar Common;
 
 import ModuleLex;
 
-@header{
+@header {
   import java.util.Stack;
 }
 
+@parser::members {
 
-@parser::members
-{
-            public boolean skipToEndOfObject()
-            {
-                Stack<Object> CurlyStack = new Stack<Object>();
-                Object o = new Object();
-                int t = _input.LA(1);
+    public void skipToEndOfObject() {
+        Stack<Object> CurlyStack = new Stack<>();
+        Object o = new Object();
+        int t = _input.LA(1);
 
-                while(t != EOF && !(CurlyStack.empty() && t == CLOSING_CURLY)){
-                    
-                    if(t == PRE_ELSE){
-                        Stack<Object> ifdefStack = new Stack<Object>();
-                        consume();
-                        t = _input.LA(1);
-                        
-                        while(t != EOF && !(ifdefStack.empty() && (t == PRE_ENDIF))){
-                            if(t == PRE_IF)
-                                ifdefStack.push(o);
-                            else if(t == PRE_ENDIF)
-                                ifdefStack.pop();
-                            consume();
-                            t = _input.LA(1);
-                        }
-                    }
-                    
-                    if(t == OPENING_CURLY)
-                        CurlyStack.push(o);
-                    else if(t == CLOSING_CURLY)
-                        CurlyStack.pop();
-                    
+        while (t != EOF && !(CurlyStack.empty() && t == CLOSING_CURLY)) {
+
+            if (t == PRE_ELSE){
+                Stack<Object> ifdefStack = new Stack<>();
+                consume();
+                t = _input.LA(1);
+
+                while (t != EOF && !(ifdefStack.empty() && (t == PRE_ENDIF))) {
+
+                    if (t == PRE_IF) ifdefStack.push(o);
+                    else if (t == PRE_ENDIF) ifdefStack.pop();
+
                     consume();
                     t = _input.LA(1);
                 }
-                if(t != EOF)
-                    consume();
-                return true;
             }
 
-   // this should go into FunctionGrammar but ANTLR fails
-   // to join the parser::members-section on inclusion
-   
-   public boolean preProcSkipToEnd()
-   {
-                Stack<Object> CurlyStack = new Stack<Object>();
-                Object o = new Object();
-                int t = _input.LA(1);
+            if (t == OPENING_CURLY) CurlyStack.push(o);
+            else if (t == CLOSING_CURLY) CurlyStack.pop();
 
-                while(t != EOF && !(CurlyStack.empty() && t == PRE_ENDIF)){
-                                        
-                    if(t == PRE_IF)
-                        CurlyStack.push(o);
-                    else if(t == PRE_ENDIF)
-                        CurlyStack.pop();
-                    
-                    consume();
-                    t = _input.LA(1);
-                }
-                if(t != EOF)
-                    consume();
-                return true;
-   }
+            consume();
+            t = _input.LA(1);
+        }
+
+        if(t != EOF) consume();
+    }
 
 }
 
@@ -147,7 +118,7 @@ rvalue_ref: '&&';
 
 class_key: 'struct' | 'class' | 'union' | 'enum';
 
-class_def: template_decl* class_key gcc_attribute? class_name? template_args? base_classes? OPENING_CURLY {skipToEndOfObject(); } ;
+class_def: template_decl* class_key gcc_attribute? class_name? template_args? base_classes? OPENING_CURLY { skipToEndOfObject(); } ;
 class_name: identifier;
 base_classes: ':' base_class (',' base_class)*;
 base_class: VIRTUAL? access_specifier? identifier template_args?;

--- a/src/main/antlr4/io/shiftleft/fuzzyc2cpg/Function.g4
+++ b/src/main/antlr4/io/shiftleft/fuzzyc2cpg/Function.g4
@@ -93,7 +93,7 @@ type_suffix : ('[' conditional_expression? ']') | param_type_list;
 simple_decl : (TYPEDEF?) var_decl;
 
 var_decl : class_def init_declarator_list? #declByClass
-         | template_decl? type_name init_declarator_list #declByType
+         | template_decl* type_name init_declarator_list #declByType
          ;
 
 init_declarator_list: init_declarator (',' init_declarator)* ';';

--- a/src/main/antlr4/io/shiftleft/fuzzyc2cpg/Function.g4
+++ b/src/main/antlr4/io/shiftleft/fuzzyc2cpg/Function.g4
@@ -1,6 +1,24 @@
 grammar Function;
 import ModuleLex, Common;
 
+@parser::members {
+   public void preProcSkipToEnd() {
+        Stack<Object> CurlyStack = new Stack<>();
+        Object o = new Object();
+        int t = _input.LA(1);
+
+        while(t != EOF && !(CurlyStack.empty() && t == PRE_ENDIF)){
+
+            if(t == PRE_IF) CurlyStack.push(o);
+            else if(t == PRE_ENDIF) CurlyStack.pop();
+
+            consume();
+            t = _input.LA(1);
+        }
+        if(t != EOF) consume();
+   }
+}
+
 statements: (pre_opener
             | pre_closer
             | pre_else {preProcSkipToEnd(); }
@@ -65,7 +83,7 @@ init_declarator: declarator '(' expr? ')' #initDeclWithCall
                | declarator #initDeclSimple
                ;
 
-declarator: ptrs? identifier type_suffix? |
+declarator: ptrs? identifier template_args? type_suffix? |
             ptrs? '(' func_ptrs identifier ')' type_suffix;
 
 type_suffix : ('[' conditional_expression? ']') | param_type_list;

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/parser/AstNodeFactory.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/parser/AstNodeFactory.java
@@ -42,7 +42,7 @@ public class AstNodeFactory {
     CharStream cs = ctx.getStart().getInputStream();
 
     if (cs.size() > 0) {
-      return startIdx <= stopIdx ? cs.toString().substring(startIdx, stopIdx + 1) : "";
+      return startIdx <= stopIdx ? cs.getText(Interval.of(startIdx, stopIdx)) : "";
     } else {
       return "";
     }

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/parser/AstNodeFactory.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/parser/AstNodeFactory.java
@@ -1,6 +1,9 @@
 package io.shiftleft.fuzzyc2cpg.parser;
 
+import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.misc.Interval;
+import scala.Char;
 
 import io.shiftleft.fuzzyc2cpg.FunctionParser.InitDeclWithAssignContext;
 import io.shiftleft.fuzzyc2cpg.FunctionParser.StatementContext;
@@ -36,21 +39,13 @@ public class AstNodeFactory {
     int startIdx = ctx.start.getStartIndex();
     int stopIdx = ctx.stop != null ? ctx.stop.getStopIndex() : -1;
 
-    String ret;
-    // Check for size > 0 is required because toString() method in
-    // ANTLR crashes on empty input streams.
-    if (ctx.getStart().getInputStream().size() > 0) {
-      ret = ctx.getStart().getInputStream().toString();
-      if(startIdx <= stopIdx) {
-        ret = ret.substring(startIdx, stopIdx + 1);
-      } else {
-        ret = "";
-      }
-    } else {
-      ret = "";
-    }
+    CharStream cs = ctx.getStart().getInputStream();
 
-    return ret;
+    if (cs.size() > 0) {
+      return startIdx <= stopIdx ? cs.toString().substring(startIdx, stopIdx + 1) : "";
+    } else {
+      return "";
+    }
   }
 
   public static void initializeFromContext(Expression node,

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/parser/ModuleFunctionParserInterface.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/parser/ModuleFunctionParserInterface.java
@@ -12,7 +12,7 @@ import org.slf4j.LoggerFactory;
 
 public class ModuleFunctionParserInterface {
 
-  static Logger logger = LoggerFactory.getLogger(ModuleFunctionParserInterface.class);
+  private static Logger logger = LoggerFactory.getLogger(ModuleFunctionParserInterface.class);
 
   // Extracts compound statement from input stream
   // as a string and passes that string to the

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/parser/TokenSubStream.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/parser/TokenSubStream.java
@@ -8,11 +8,11 @@ import org.antlr.v4.runtime.TokenSource;
 
 public class TokenSubStream extends CommonTokenStream {
 
-  protected int stopIndex = -1;
-  protected int startIndex = 0;
+  private int stopIndex = -1;
+  private int startIndex = 0;
 
-  protected Stack<Integer> stopIndexStack = new Stack<Integer>();
-  protected Stack<Integer> startIndexStack = new Stack<Integer>();
+  private Stack<Integer> stopIndexStack = new Stack<Integer>();
+  private Stack<Integer> startIndexStack = new Stack<Integer>();
 
   public TokenSubStream(TokenSource tokenSource) {
     super(tokenSource);
@@ -41,22 +41,13 @@ public class TokenSubStream extends CommonTokenStream {
 
   @Override
   public Token LT(int k) {
-    lazyInit();
-    if (k == 0) {
-      return null;
-    }
-    if (k < 0) {
-      return LB(-k);
-    }
-
-    int i = p + k - 1;
-    sync(i);
-
-    if (i >= tokens.size() || (stopIndex != -1 && i >= stopIndex)) { // return EOF token
-      // EOF must be last token
+    int newIdx = p + k - 1;
+    if (stopIndex != -1 && newIdx >= stopIndex) {
+      sync(newIdx);
       return tokens.get(tokens.size() - 1);
+    } else {
+      return super.LT(k);
     }
-    return tokens.get(i);
   }
 
 }

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/parser/functions/builder/FunctionContentBuilder.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/parser/functions/builder/FunctionContentBuilder.java
@@ -533,8 +533,7 @@ public class FunctionContentBuilder extends AstNodeBuilder<AstNode> {
     IdentifierDeclBuilder declBuilder = new IdentifierDeclBuilder();
     declBuilder.createNew(ctx);
     declBuilder.setType(wrappedContext, typeName);
-    IdentifierDecl identifierDecl = (IdentifierDecl) declBuilder.getItem();
-    return identifierDecl;
+    return declBuilder.getItem();
   }
 
   private ParserRuleContext getTypeFromParent() {

--- a/src/test/java/io/shiftleft/fuzzyc2cpg/antlrparsers/functionparser/AssignmentTests.java
+++ b/src/test/java/io/shiftleft/fuzzyc2cpg/antlrparsers/functionparser/AssignmentTests.java
@@ -1,18 +1,16 @@
 package io.shiftleft.fuzzyc2cpg.antlrparsers.functionparser;
 
-
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import io.shiftleft.fuzzyc2cpg.parser.AntlrParserDriver;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.junit.Test;
 
-public class AssignmentTests extends FunctionParserTestBase
-{
+public class AssignmentTests extends FunctionParserTestBase {
 
 	@Test
-	public void testAssignmentExpr()
-	{
+	public void testAssignmentExpr() {
 		String input = "x = y + 1;";
 		AntlrParserDriver functionParser = createFunctionDriver();
 		ParseTree tree = functionParser.parseString(input);
@@ -21,8 +19,7 @@ public class AssignmentTests extends FunctionParserTestBase
 	}
 
 	@Test
-	public void testComplexAssignment()
-	{
+	public void testComplexAssignment() {
 		String input = "k += ((c = text[k]) >= sBMHCharSetSize) ? patlen : skip[c];";
 		AntlrParserDriver functionParser = createFunctionDriver();
 		ParseTree tree = functionParser.parseString(input);
@@ -31,13 +28,11 @@ public class AssignmentTests extends FunctionParserTestBase
 	}
 
 	@Test
-	public void testPrivateInName()
-	{
+	public void testPrivateInName() {
 		String input = "struct acpi_battery *battery = m->private;";
 		AntlrParserDriver functionParser = createFunctionDriver();
 		ParseTree tree = functionParser.parseString(input);
 		String output = tree.toStringTree(functionParser.getAntlrParser());
 		assertTrue(output.contains("simple_decl"));
 	}
-
 }

--- a/src/test/java/io/shiftleft/fuzzyc2cpg/antlrparsers/functionparser/FunctionCommentTests.java
+++ b/src/test/java/io/shiftleft/fuzzyc2cpg/antlrparsers/functionparser/FunctionCommentTests.java
@@ -38,6 +38,20 @@ public class FunctionCommentTests extends FunctionParserTestBase {
     assertEquals(parser.getCurrentToken().getText(), "/* This is a block comment! */");
   }
 
+  @Test
+  public void testLineCommentWithEmoji() {
+    String input = "int x = 5; // Peachy! \uD83C\uDF51";
+    FunctionParser parser = createHiddenParser(input);
+    assertEquals(parser.getCurrentToken().getText(), "// Peachy! \uD83C\uDF51");
+  }
+
+  @Test
+  public void testBlockCommentWithEmoji() {
+    String input = "int x = 5; // Peachy! \uD83C\uDF51";
+    FunctionParser parser = createHiddenParser(input);
+    assertEquals(parser.getCurrentToken().getText(), "// Peachy! \uD83C\uDF51");
+  }
+
   private void compareParses(String actual, String expected) {
     AntlrParserDriver functionParser = createFunctionDriver();
     ParseTree actualTree = functionParser.parseString(actual);
@@ -71,6 +85,20 @@ public class FunctionCommentTests extends FunctionParserTestBase {
   @Test
   public void testBlockCommentWithinStatementDriver() {
     String inputWithComment = "int /* This is a block comment! */ x = 5;";
+    String inputWithoutComment = "int x = 5;";
+    compareParses(inputWithComment, inputWithoutComment);
+  }
+
+  @Test
+  public void testLineCommentWithEmojiDriver() {
+    String inputWithComment = "int x = 5; // Peachy! \uD83C\uDF51";
+    String inputWithoutComment = "int x = 5;";
+    compareParses(inputWithComment, inputWithoutComment);
+  }
+
+  @Test
+  public void testBlockCommentWithEmojiDriver() {
+    String inputWithComment = "int /* Peachy! \uD83C\uDF51 */ x = 5;";
     String inputWithoutComment = "int x = 5;";
     compareParses(inputWithComment, inputWithoutComment);
   }

--- a/src/test/java/io/shiftleft/fuzzyc2cpg/antlrparsers/functionparser/FunctionParserTest.java
+++ b/src/test/java/io/shiftleft/fuzzyc2cpg/antlrparsers/functionparser/FunctionParserTest.java
@@ -10,11 +10,11 @@ import org.junit.Test;
 public class FunctionParserTest extends FunctionParserTestBase
 {
 
-  private String generateParserOutput(String input) {
-    AntlrParserDriver functionParser = createFunctionDriver();
-    ParseTree tree = functionParser.parseString(input);
-    return tree.toStringTree(functionParser.getAntlrParser());
-  }
+	private String generateParserOutput(String input) {
+		AntlrParserDriver functionParser = createFunctionDriver();
+		ParseTree tree = functionParser.parseString(input);
+		return tree.toStringTree(functionParser.getAntlrParser());
+	}
 
 	@Test
 	public void testIf()
@@ -28,7 +28,7 @@ public class FunctionParserTest extends FunctionParserTestBase
 	public void testStructInFunc()
 	{
 		String input = "class foo{ int x; };";
-    String output = generateParserOutput(input);;
+    	String output = generateParserOutput(input);;
 		assertTrue(output.contains("class_def"));
 	}
 
@@ -36,14 +36,14 @@ public class FunctionParserTest extends FunctionParserTestBase
 	public void testSizeofStruct()
 	{
 		String input = "while((buffer + len) > (tmp + sizeof(struct stun_attrib))) {}";
-    String output = generateParserOutput(input);
+    	String output = generateParserOutput(input);
 		assertTrue(output.contains("selection_or_iteration while"));
 	}
 
 	@Test
 	public void testAutoWithinIf() {
 		String input = "if (auto x = 1) { return 1; } else { return 2; }";
-    String output = generateParserOutput(input);
+    	String output = generateParserOutput(input);
 		assertTrue(output.contains("(base_type auto)) (declarator (identifier x))"));
 	}
 
@@ -53,18 +53,27 @@ public class FunctionParserTest extends FunctionParserTestBase
 			"\"a multiline \"\n" +
 			"\"string.\";";
 
-    String output = generateParserOutput(input);
+    	String output = generateParserOutput(input);
 		assertEquals(
 			"(statements (statement (simple_decl (var_decl (type_name (base_type char)) (init_declarator_list (init_declarator (declarator (ptrs (ptr_operator *)) (identifier c)) = (initializer (assign_expr (conditional_expression (or_expression (and_expression (inclusive_or_expression (exclusive_or_expression (bit_and_expression (equality_expression (relational_expression (shift_expression (additive_expression (multiplicative_expression (cast_expression (unary_expression (postfix_expression (primary_expression (constant \"This is \"\\n\"a multiline \"\\n\"string.\"))))))))))))))))))) ;)))))",
 			output);
 	}
 
 	@Test
-  public void testStringConcatWithIdentifier() {
-	  String input = "char* c = \"start\"SOME_VAR\"end\";";
-    String output = generateParserOutput(input);
-    assertEquals(
-    	"(statements (statement (simple_decl (var_decl (type_name (base_type char)) (init_declarator_list (init_declarator (declarator (ptrs (ptr_operator *)) (identifier c)) = (initializer (assign_expr (conditional_expression (or_expression (and_expression (inclusive_or_expression (exclusive_or_expression (bit_and_expression (equality_expression (relational_expression (shift_expression (additive_expression (multiplicative_expression (cast_expression (unary_expression (postfix_expression (primary_expression (constant \"start\"SOME_VAR\"end\"))))))))))))))))))) ;)))))",
+    public void testStringConcatWithIdentifier() {
+	    String input = "char* c = \"start\"SOME_VAR\"end\";";
+		String output = generateParserOutput(input);
+
+		assertEquals("(statements (statement (simple_decl (var_decl (type_name (base_type char)) (init_declarator_list (init_declarator (declarator (ptrs (ptr_operator *)) (identifier c)) = (initializer (assign_expr (conditional_expression (or_expression (and_expression (inclusive_or_expression (exclusive_or_expression (bit_and_expression (equality_expression (relational_expression (shift_expression (additive_expression (multiplicative_expression (cast_expression (unary_expression (postfix_expression (primary_expression (constant \"start\"SOME_VAR\"end\"))))))))))))))))))) ;)))))",
 			output);
-  }
+    }
+
+	@Test
+	public void testAssignmentWithEmojiComment() {
+		String input = "// This is the peach emoji: \uD83C\uDF51\n" +
+					   "const auto derefed = *ref;\n";
+		String output = generateParserOutput(input);
+		assertEquals("(statements (statement (simple_decl (var_decl (type_name const (base_type auto)) (init_declarator_list (init_declarator (declarator (identifier derefed)) = (initializer (assign_expr (conditional_expression (or_expression (and_expression (inclusive_or_expression (exclusive_or_expression (bit_and_expression (equality_expression (relational_expression (shift_expression (additive_expression (multiplicative_expression (cast_expression (unary_expression (unary_op_and_cast_expr (unary_operator *) (cast_expression (unary_expression (postfix_expression (primary_expression (identifier ref)))))))))))))))))))))) ;)))))",
+					 output);
+	}
 }

--- a/src/test/java/io/shiftleft/fuzzyc2cpg/antlrparsers/moduleparser/ModuleCommentTests.java
+++ b/src/test/java/io/shiftleft/fuzzyc2cpg/antlrparsers/moduleparser/ModuleCommentTests.java
@@ -31,6 +31,17 @@ public class ModuleCommentTests extends ModuleParserTest {
   }
 
   @Test
+  public void shouldParseSingleLineCommentWithEmojiInFunction() {
+    String input = "static int altgid(void){\n" +
+            "// This is the peach emoji: \uD83C\uDF51\n" +
+            "return 1;\n" +
+            "}";
+    ModuleParser parser = createHiddenParser(input);
+    assertTokenEqualsString(parser.getCurrentToken(), "// This is the peach emoji: \uD83C\uDF51\n");
+  }
+
+
+  @Test
   public void shouldParseSingleLineCommentInStruct() {
     String input = "struct foo {\n" +
       "int x;\n" +

--- a/src/test/java/io/shiftleft/fuzzyc2cpg/antlrparsers/moduleparser/ModuleParserTest.java
+++ b/src/test/java/io/shiftleft/fuzzyc2cpg/antlrparsers/moduleparser/ModuleParserTest.java
@@ -1,11 +1,12 @@
 package io.shiftleft.fuzzyc2cpg.antlrparsers.moduleparser;
 
-import io.shiftleft.fuzzyc2cpg.ModuleLexer;
-import io.shiftleft.fuzzyc2cpg.ModuleParser;
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.Token;
+
+import io.shiftleft.fuzzyc2cpg.ModuleLexer;
+import io.shiftleft.fuzzyc2cpg.ModuleParser;
 
 public class ModuleParserTest {
 
@@ -24,5 +25,4 @@ public class ModuleParserTest {
 		ModuleParser parser = new ModuleParser(tokens);
 		return parser;
 	}
-
 }

--- a/src/test/java/io/shiftleft/fuzzyc2cpg/antlrparsers/moduleparser/OtherTests.java
+++ b/src/test/java/io/shiftleft/fuzzyc2cpg/antlrparsers/moduleparser/OtherTests.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import io.shiftleft.fuzzyc2cpg.ModuleParser;
+
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class OtherTests extends ModuleParserTest
@@ -72,5 +74,21 @@ public class OtherTests extends ModuleParserTest
 
 		assertEquals("(simple_decl (var_decl (type_name (base_type int)) (init_declarator_list (init_declarator (declarator (identifier x))) , (init_declarator (declarator (identifier y))) ;)))",
 				     output);
+	}
+
+	// See https://github.com/ShiftLeftSecurity/fuzzyc2cpg/issues/158
+	@Test
+	public void testEmojiFuncComment() {
+		String input = "int meaning_of_life() {\n" +
+					   "  // This is the peach emoji: \uD83C\uDF51\n" +
+					   "  const auto x = *y;\n" +
+				 	   "  return 42;\n" +
+				       "}";
+
+		ModuleParser parser = createParser(input);
+		String output = parser.function_def().toStringTree(parser);
+
+		assertEquals("(function_def (return_type (type_name (base_type int))) (function_name (identifier meaning_of_life)) (function_param_list ( )) (compound_statement { const auto x = * y ; return 42 ; }))",
+				output);
 	}
 }

--- a/test.cpp
+++ b/test.cpp
@@ -1,0 +1,6 @@
+int main() {
+  // A stunning peach: 🍑
+  const auto x = *y;
+  return 42;
+}
+

--- a/test.cpp
+++ b/test.cpp
@@ -1,6 +1,0 @@
-int main() {
-  // A stunning peach: 🍑
-  const auto x = *y;
-  return 42;
-}
-


### PR DESCRIPTION
Previously, when parsing the source into the AST, we were attempting to extract the original code string using the Java `String` API:
```java
cs.toString().substring(startIdx, stopIdx + 1);
```

The issue with this is that many emojis are made up of multiple Unicode code points. As the Java String API is not smart in handling these, the emoji would cause us to parse these incorrectly (usually off-by-one). By using the built-in Antlr API for getting text using `Interval`s, we no longer have to worry about handling these code points ourselves:
```java
cs.getText(Interval.of(startIdx, stopIdx));
```

This will return the text in the specified range, taking multiple code points into account.

Whilst investigating, I took the opportunity to perform some cleanup around the codebase, including:
- Restricting the scope of functions defined in grammar files.
- Removing duplicated logic in `TokenSubStream`.
- Adding extra tests around the parsing of comments, particularly around emojis.
- General code style cleanup.

