### PR TITLE
upgrade to scala 2.13.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,23 +1,24 @@
 name := "fuzzyc2cpg"
 organization := "io.shiftleft"
-scalaVersion := "2.12.10"
+scalaVersion := "2.13.1"
 enablePlugins(GitVersioning)
 
-val cpgVersion = "0.10.127"
+val cpgVersion = "0.10.142+3-00751789"
 val antlrVersion = "4.7.2"
 
 libraryDependencies ++= Seq(
-  "com.github.scopt"     %% "scopt"                    % "3.7.0",
+  "com.github.scopt"     %% "scopt"                    % "3.7.1",
   "org.antlr"            %  "antlr4-runtime"           % antlrVersion,
   "io.shiftleft"         %% "codepropertygraph"        % cpgVersion,
   "io.shiftleft"         %% "codepropertygraph-protos" % cpgVersion,
   "ch.qos.logback"       %  "logback-classic"          % "1.2.3",
   "commons-cli"          %  "commons-cli"              % "1.4",
-  "com.github.pathikrit" %% "better-files"             % "3.1.0",
+  "com.github.pathikrit" %% "better-files"             % "3.8.0",
+  "org.scala-lang.modules" %% "scala-parallel-collections" % "0.2.0",
 
   "com.novocode"         %  "junit-interface"          % "0.11"  % Test,
   "junit"                %  "junit"                    % "4.12"  % Test,
-  "org.scalatest"        %% "scalatest"                % "3.0.3" % Test,
+  "org.scalatest"        %% "scalatest"                % "3.0.8" % Test,
   "org.apache.tinkerpop" %  "tinkergraph-gremlin"      % "3.4.3" % Test,
 )
 
@@ -51,9 +52,7 @@ scalacOptions ++= Seq(
   "-unchecked",                        // Enable additional warnings where generated code depends on assumptions.
   "-Xcheckinit",                       // Wrap field accessors to throw an exception on uninitialized access.
   // "-Xfatal-warnings",                  // Fail the compilation if there are any warnings.
-  "-Xfuture",                          // Turn on future language features.
   "-Xlint:adapted-args",               // Warn if an argument list is modified to match the receiver.
-  "-Xlint:by-name-right-associative",  // By-name parameter of right associative operator.
   "-Xlint:constant",                   // Evaluation of a constant arithmetic expression results in an error.
   "-Xlint:delayedinit-select",         // Selecting member of DelayedInit.
   "-Xlint:doc-detached",               // A Scaladoc comment appears to be detached from its element.
@@ -66,15 +65,10 @@ scalacOptions ++= Seq(
   "-Xlint:private-shadow",             // A private field (or class parameter) shadows a superclass field.
   "-Xlint:stars-align",                // Pattern sequence wildcard must align with sequence component.
   "-Xlint:type-parameter-shadow",      // A local type parameter shadows a type already in scope.
-  "-Xlint:unsound-match",              // Pattern match may not be typesafe.
-  "-Yno-adapted-args",                 // Do not adapt an argument list (either by inserting () or creating a tuple) to match the receiver.
-  "-Ypartial-unification",             // Enable partial unification in type constructor inference
   "-Ywarn-dead-code",                  // Warn when dead code is identified.
   "-Ywarn-extra-implicit",             // Warn when more than one implicit parameter section is defined.
-  "-Ywarn-inaccessible",               // Warn about inaccessible types in method signatures.
-  "-Ywarn-infer-any",                  // Warn when a type argument is inferred to be `Any`.
-  "-Ywarn-nullary-override",           // Warn when non-nullary `def f()' overrides nullary `def f'.
-  // "-Ywarn-nullary-unit",               // Warn when nullary methods return Unit.
+  "-Xlint:nullary-override",           // Warn when non-nullary def f() overrides nullary def f.
+  "-Xlint:nullary-unit",               // Warn when nullary methods return Unit.
   "-Ywarn-numeric-widen",              // Warn when numerics are widened.
   "-Ywarn-unused:implicits",           // Warn if an implicit parameter is unused.
   "-Ywarn-unused:imports",             // Warn if an import selector is not referenced.

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ organization := "io.shiftleft"
 scalaVersion := "2.13.1"
 enablePlugins(GitVersioning)
 
-val cpgVersion = "0.10.142+3-00751789"
+val cpgVersion = "0.10.154+14-97ddd6b5"
 val antlrVersion = "4.7.2"
 
 libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -34,6 +34,7 @@ resolvers += "Sonatype OSS" at "https://oss.sonatype.org/content/repositories/pu
 ThisBuild / resolvers ++= Seq(
   Resolver.mavenLocal,
   Resolver.bintrayRepo("shiftleft", "maven"),
+  Resolver.bintrayRepo("mpollmeier", "maven"),
   "Artifactory release local" at "https://shiftleft.jfrog.io/shiftleft/libs-release-local",
   "Apache public" at "https://repository.apache.org/content/groups/public/",
   "Sonatype OSS" at "https://oss.sonatype.org/content/repositories/public",

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
@@ -16,6 +16,7 @@ import java.nio.file.{Files, Path}
 
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
+import scala.collection.parallel.CollectionConverters._
 import scala.util.control.NonFatal
 
 class FuzzyC2Cpg(outputModuleFactory: CpgOutputModuleFactory) {
@@ -45,12 +46,12 @@ class FuzzyC2Cpg(outputModuleFactory: CpgOutputModuleFactory) {
     val sourceFileNames = SourceFiles.determine(sourcePaths, sourceFileExtensions)
 
     val commandBuffer = new ListBuffer[String]()
-    commandBuffer.append(preprocessorExecutable, "--verbose", "-o", preprocessedPath.toString)
-    if (sourceFileNames.nonEmpty) commandBuffer.append("-f", sourceFileNames.mkString(","))
-    if (includeFiles.nonEmpty) commandBuffer.append("--include", includeFiles.mkString(","))
-    if (includePaths.nonEmpty) commandBuffer.append("-I", includePaths.mkString(","))
-    if (defines.nonEmpty) commandBuffer.append("-D", defines.mkString(","))
-    if (undefines.nonEmpty) commandBuffer.append("-U", defines.mkString(","))
+    commandBuffer.appendAll(List(preprocessorExecutable, "--verbose", "-o", preprocessedPath.toString))
+    if (sourceFileNames.nonEmpty) commandBuffer.appendAll(List("-f", sourceFileNames.mkString(",")))
+    if (includeFiles.nonEmpty) commandBuffer.appendAll(List("--include", includeFiles.mkString(",")))
+    if (includePaths.nonEmpty) commandBuffer.appendAll(List("-I", includePaths.mkString(",")))
+    if (defines.nonEmpty) commandBuffer.appendAll(List("-D", defines.mkString(",")))
+    if (undefines.nonEmpty) commandBuffer.appendAll(List("-U", defines.mkString(",")))
 
     val cmd = commandBuffer.toList
 
@@ -84,7 +85,7 @@ class FuzzyC2Cpg(outputModuleFactory: CpgOutputModuleFactory) {
     outputModuleFactory.persist()
   }
 
-  private def addFunctionDeclarations: Unit = {
+  private def addFunctionDeclarations(): Unit = {
     FuzzyC2CpgCache.sortedSignatures.foreach { signature =>
       FuzzyC2CpgCache.getDeclarations(signature).foreach {
         case (outputIdentifier, bodyCpg) =>

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgConverter.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgConverter.scala
@@ -1,6 +1,6 @@
 package io.shiftleft.fuzzyc2cpg.astnew
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import io.shiftleft.codepropertygraph.generated.{EvaluationStrategies, Operators}
 import io.shiftleft.fuzzyc2cpg.Defines
 import io.shiftleft.fuzzyc2cpg.adapter.{CpgAdapter, EdgeKind, NodeKind, NodeProperty}


### PR DESCRIPTION
based on https://github.com/ShiftLeftSecurity/fuzzyc2cpg/pull/94 which
had to be reverted.

Some scalac options have been removed, others have been renamed. I
hope I kept the intentions as before.

Unfortunately we have a cyclic dependency with codepropertygraph, but
since it's only a test dependency I took the shortcut of publishing a
2.13 release for codepropertygraph which we use here. Once fuzzyc2cpg
is published for scala 2.13, we can release a normal cpg version which
we can depend on here.
Long term we should resolve the cyclic dependency.