### PR TITLE
Support new and delete expressions in the CPG.

### DIFF
--- a/src/main/antlr4/io/shiftleft/fuzzyc2cpg/Common.g4
+++ b/src/main/antlr4/io/shiftleft/fuzzyc2cpg/Common.g4
@@ -158,18 +158,20 @@ cast_expression: ('(' cast_target ')' cast_expression)
 
 cast_target: type_name ptr_operator*;
 
-// currently does not implement delete
-
 unary_expression: inc_dec cast_expression
                 | unary_op_and_cast_expr
                 | sizeof_expression 
                 | new_expression
+                | delete_expression
                 | postfix_expression
                 ;
 
 new_expression: '::'? NEW type_name '[' conditional_expression? ']' 
               | '::'? NEW type_name '(' expr? ')'
               ;
+
+delete_expression: DELETE identifier |
+                   DELETE '[' ']' identifier;
 
 unary_op_and_cast_expr: unary_operator cast_expression;
 

--- a/src/main/antlr4/io/shiftleft/fuzzyc2cpg/ModuleLex.g4
+++ b/src/main/antlr4/io/shiftleft/fuzzyc2cpg/ModuleLex.g4
@@ -29,6 +29,7 @@ AUTO: 'auto'; REGISTER: 'register';
 OPERATOR: 'operator';
 TEMPLATE: 'template';
 NEW: 'new';
+DELETE: 'delete';
 
 GCC_ATTRIBUTE : '__attribute__';
 

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/ast/expressions/DeleteExpression.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/ast/expressions/DeleteExpression.java
@@ -1,0 +1,24 @@
+package io.shiftleft.fuzzyc2cpg.ast.expressions;
+
+import io.shiftleft.fuzzyc2cpg.FunctionParser;
+import io.shiftleft.fuzzyc2cpg.ast.walking.ASTNodeVisitor;
+import io.shiftleft.fuzzyc2cpg.parser.AstNodeFactory;
+
+public class DeleteExpression extends CallExpressionBase {
+    private Identifier target;
+
+    public Identifier getTarget() {
+        return this.target;
+    }
+
+    public void setTarget(FunctionParser.IdentifierContext ctx) {
+        this.target = new Identifier();
+        AstNodeFactory.initializeFromContext(target, ctx);
+        super.addChild(target);
+    }
+
+    @Override
+    public void accept(ASTNodeVisitor visitor) {
+        visitor.visit(this);
+    }
+}

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/ast/expressions/NewExpression.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/ast/expressions/NewExpression.java
@@ -1,17 +1,20 @@
 package io.shiftleft.fuzzyc2cpg.ast.expressions;
 
+import io.shiftleft.fuzzyc2cpg.FunctionParser;
 import io.shiftleft.fuzzyc2cpg.ast.walking.ASTNodeVisitor;
+import io.shiftleft.fuzzyc2cpg.parser.AstNodeFactory;
 
 public class NewExpression extends CallExpressionBase {
 
-  private Expression targetClass = null;
+  private Identifier targetClass;
 
-  public Expression getTargetClass() {
+  public Identifier getTargetClass() {
     return this.targetClass;
   }
 
-  public void setTargetClass(Expression targetClass) {
-    this.targetClass = targetClass;
+  public void setTargetClass(FunctionParser.Type_nameContext ctx) {
+    this.targetClass = new Identifier();
+    AstNodeFactory.initializeFromContext(targetClass, ctx);
     super.addChild(targetClass);
   }
 

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/ast/walking/ASTNodeVisitor.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/ast/walking/ASTNodeVisitor.java
@@ -4,54 +4,7 @@ import io.shiftleft.fuzzyc2cpg.ast.AstNode;
 import io.shiftleft.fuzzyc2cpg.ast.declarations.ClassDefStatement;
 import io.shiftleft.fuzzyc2cpg.ast.declarations.IdentifierDecl;
 import io.shiftleft.fuzzyc2cpg.ast.declarations.IdentifierDeclType;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.AdditiveExpression;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.AndExpression;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.Argument;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.ArgumentList;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.ArrayIndexing;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.AssignmentExpression;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.BinaryExpression;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.BinaryOperationExpression;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.BitAndExpression;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.CallExpressionBase;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.Callee;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.CastExpression;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.CastTarget;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.ClassConstantExpression;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.ConditionalExpression;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.Constant;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.DoubleExpression;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.EqualityExpression;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.ExclusiveOrExpression;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.Expression;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.ExpressionList;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.ForInit;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.Identifier;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.IdentifierList;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.IncDec;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.InclusiveOrExpression;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.InitializerList;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.InstanceofExpression;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.IntegerExpression;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.MemberAccess;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.MultiplicativeExpression;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.NewExpression;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.OrExpression;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.PostIncDecOperationExpression;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.PostfixExpression;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.PrimaryExpression;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.PropertyExpression;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.PtrMemberAccess;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.RelationalExpression;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.ShiftExpression;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.Sizeof;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.SizeofOperand;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.StaticPropertyExpression;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.StringExpression;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.UnaryExpression;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.UnaryOperationExpression;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.UnaryOperator;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.Variable;
+import io.shiftleft.fuzzyc2cpg.ast.expressions.*;
 import io.shiftleft.fuzzyc2cpg.ast.functionDef.*;
 import io.shiftleft.fuzzyc2cpg.ast.langc.expressions.CallExpression;
 import io.shiftleft.fuzzyc2cpg.ast.langc.expressions.SizeofExpression;
@@ -65,7 +18,6 @@ import io.shiftleft.fuzzyc2cpg.ast.logical.statements.BlockStarter;
 import io.shiftleft.fuzzyc2cpg.ast.logical.statements.BlockStarterWithStmtAndCnd;
 import io.shiftleft.fuzzyc2cpg.ast.logical.statements.BreakOrContinueStatement;
 import io.shiftleft.fuzzyc2cpg.ast.logical.statements.CompoundStatement;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.Condition;
 import io.shiftleft.fuzzyc2cpg.ast.logical.statements.JumpStatement;
 import io.shiftleft.fuzzyc2cpg.ast.logical.statements.Label;
 import io.shiftleft.fuzzyc2cpg.ast.logical.statements.Statement;
@@ -232,6 +184,10 @@ public interface ASTNodeVisitor {
 
   default void visit(NewExpression expression) {
     visit((CallExpressionBase)expression);
+  }
+
+  default void visit(DeleteExpression expression) {
+    visit((CallExpressionBase) expression);
   }
 
   default void visit(OrExpression expression) {

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/parser/functions/CFunctionParseTreeListener.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/parser/functions/CFunctionParseTreeListener.java
@@ -774,4 +774,27 @@ public class CFunctionParseTreeListener extends FunctionBaseListener {
     builder.enterThrowStatement(ctx);
   }
 
+  @Override
+  public void enterNew_expression(FunctionParser.New_expressionContext ctx) {
+    FunctionContentBuilder builder = (FunctionContentBuilder) p.builderStack.peek();
+    builder.enterNewExpr(ctx);
+  }
+
+  @Override
+  public void exitNew_expression(FunctionParser.New_expressionContext ctx) {
+    FunctionContentBuilder builder = (FunctionContentBuilder) p.builderStack.peek();
+    builder.exitNewExpr(ctx);
+  }
+
+  @Override
+  public void enterDelete_expression(FunctionParser.Delete_expressionContext ctx) {
+    FunctionContentBuilder builder = (FunctionContentBuilder) p.builderStack.peek();
+    builder.enterDeleteExpr(ctx);
+  }
+
+  @Override
+  public void exitDelete_expression(FunctionParser.Delete_expressionContext ctx) {
+    FunctionContentBuilder builder = (FunctionContentBuilder) p.builderStack.peek();
+    builder.exitDeleteExpr(ctx);
+  }
 }

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/parser/functions/builder/FunctionContentBuilder.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/parser/functions/builder/FunctionContentBuilder.java
@@ -1,5 +1,6 @@
 package io.shiftleft.fuzzyc2cpg.parser.functions.builder;
 
+import io.shiftleft.fuzzyc2cpg.FunctionParser;
 import io.shiftleft.fuzzyc2cpg.FunctionParser.Additive_expressionContext;
 import io.shiftleft.fuzzyc2cpg.FunctionParser.And_expressionContext;
 import io.shiftleft.fuzzyc2cpg.FunctionParser.ArrayIndexingContext;
@@ -63,7 +64,7 @@ import io.shiftleft.fuzzyc2cpg.FunctionParser.Unary_operatorContext;
 import io.shiftleft.fuzzyc2cpg.FunctionParser.While_statementContext;
 import io.shiftleft.fuzzyc2cpg.ast.AstNode;
 import io.shiftleft.fuzzyc2cpg.ast.AstNodeBuilder;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.Constant;
+import io.shiftleft.fuzzyc2cpg.ast.expressions.*;
 import io.shiftleft.fuzzyc2cpg.ast.langc.expressions.CallExpression;
 import io.shiftleft.fuzzyc2cpg.ast.langc.expressions.SizeofExpression;
 import io.shiftleft.fuzzyc2cpg.ast.langc.statements.blockstarters.ElseStatement;
@@ -71,42 +72,9 @@ import io.shiftleft.fuzzyc2cpg.ast.langc.statements.blockstarters.IfStatement;
 import io.shiftleft.fuzzyc2cpg.ast.declarations.ClassDefStatement;
 import io.shiftleft.fuzzyc2cpg.ast.declarations.IdentifierDecl;
 import io.shiftleft.fuzzyc2cpg.ast.declarations.IdentifierDeclType;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.AdditiveExpression;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.AndExpression;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.Argument;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.ArgumentList;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.ArrayIndexing;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.AssignmentExpression;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.BitAndExpression;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.Callee;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.CastExpression;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.CastTarget;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.ConditionalExpression;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.EqualityExpression;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.ExclusiveOrExpression;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.Expression;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.ForInit;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.Identifier;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.IncDec;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.InclusiveOrExpression;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.InitializerList;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.MemberAccess;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.MultiplicativeExpression;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.OrExpression;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.PostIncDecOperationExpression;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.PrimaryExpression;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.PtrMemberAccess;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.RelationalExpression;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.ShiftExpression;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.Sizeof;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.SizeofOperand;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.UnaryExpression;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.UnaryOperationExpression;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.UnaryOperator;
 import io.shiftleft.fuzzyc2cpg.ast.logical.statements.BlockCloser;
 import io.shiftleft.fuzzyc2cpg.ast.logical.statements.BlockStarter;
 import io.shiftleft.fuzzyc2cpg.ast.logical.statements.CompoundStatement;
-import io.shiftleft.fuzzyc2cpg.ast.expressions.Condition;
 import io.shiftleft.fuzzyc2cpg.ast.logical.statements.Label;
 import io.shiftleft.fuzzyc2cpg.ast.logical.statements.Statement;
 import io.shiftleft.fuzzyc2cpg.ast.statements.ExpressionStatement;
@@ -548,7 +516,7 @@ public class FunctionContentBuilder extends AstNodeBuilder<AstNode> {
       typeName = nodeToRuleContext.get(name);
     } else {
       throw new RuntimeException(
-          "No matching declaration statement/class definiton for init declarator");
+          "No matching declaration statement/class definition for init declarator");
     }
     return typeName;
   }
@@ -804,4 +772,28 @@ public class FunctionContentBuilder extends AstNodeBuilder<AstNode> {
     replaceTopOfStack(new ThrowStatement(), ctx);
   }
 
+    public void enterNewExpr(FunctionParser.New_expressionContext ctx) {
+      NewExpression expr = new NewExpression();
+      expr.setTargetClass(ctx.type_name());
+      // TODO: Set the arg list (e.g. class ctor params & array size)
+      expr.setArgumentList(new ArgumentList());
+      nodeToRuleContext.put(expr, ctx);
+      stack.push(expr);
+  }
+
+  public void exitNewExpr(FunctionParser.New_expressionContext ctx) {
+    nesting.consolidateSubExpression(ctx);
+  }
+
+  public void enterDeleteExpr(FunctionParser.Delete_expressionContext ctx) {
+    DeleteExpression expr = new DeleteExpression();
+    expr.setTarget(ctx.identifier());
+    expr.setArgumentList(new ArgumentList());
+    nodeToRuleContext.put(expr, ctx);
+    stack.push(expr);
+  }
+
+  public void exitDeleteExpr(FunctionParser.Delete_expressionContext ctx) {
+    nesting.consolidateSubExpression(ctx);
+  }
 }

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/parser/functions/builder/NestingReconstructor.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/parser/functions/builder/NestingReconstructor.java
@@ -1,6 +1,7 @@
 package io.shiftleft.fuzzyc2cpg.parser.functions.builder;
 
 import io.shiftleft.fuzzyc2cpg.ast.AstNode;
+import io.shiftleft.fuzzyc2cpg.ast.expressions.NewExpression;
 import io.shiftleft.fuzzyc2cpg.ast.langc.statements.blockstarters.ElseStatement;
 import io.shiftleft.fuzzyc2cpg.ast.langc.statements.blockstarters.IfStatement;
 import io.shiftleft.fuzzyc2cpg.ast.expressions.Expression;

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgConverter.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgConverter.scala
@@ -361,6 +361,27 @@ class AstToCpgConverter[NodeBuilderType, NodeType, EdgeBuilderType, EdgeType](
     popContext()
   }
 
+  override def visit(astNew: NewExpression): Unit = {
+    val call = createCallNode(astNew, "<operator>.new")
+
+    addAstChild(call)
+    pushContext(call, 1)
+    context.addArgumentEdgeOnNextAstEdge = true
+    astNew.getTargetClass.accept(this)
+    astNew.getArgumentList.accept(this)
+    popContext()
+  }
+
+  override def visit(astDelete: DeleteExpression): Unit = {
+    val call = createCallNode(astDelete, Operators.delete);
+
+    addAstChild(call)
+    pushContext(call, 1)
+    context.addArgumentEdgeOnNextAstEdge = true;
+    astDelete.getTarget.accept(this)
+    popContext()
+  }
+
   override def visit(astConstant: Constant): Unit = {
     val constantType = deriveConstantTypeFromCode(astConstant.getEscapedCodeStr)
     val cpgConstant = adapter

--- a/src/test/java/io/shiftleft/fuzzyc2cpg/antlrparsers/functionparser/FunctionParserTest.java
+++ b/src/test/java/io/shiftleft/fuzzyc2cpg/antlrparsers/functionparser/FunctionParserTest.java
@@ -76,4 +76,27 @@ public class FunctionParserTest extends FunctionParserTestBase
 		assertEquals("(statements (statement (simple_decl (var_decl (type_name const (base_type auto)) (init_declarator_list (init_declarator (declarator (identifier derefed)) = (initializer (assign_expr (conditional_expression (or_expression (and_expression (inclusive_or_expression (exclusive_or_expression (bit_and_expression (equality_expression (relational_expression (shift_expression (additive_expression (multiplicative_expression (cast_expression (unary_expression (unary_op_and_cast_expr (unary_operator *) (cast_expression (unary_expression (postfix_expression (primary_expression (identifier ref)))))))))))))))))))))) ;)))))",
 					 output);
 	}
+
+	@Test
+	public void testNew() {
+		String input = "int x = new uint8_t[42];";
+		String output = generateParserOutput(input);
+		assertEquals("(statements (statement (simple_decl (var_decl (type_name (base_type int)) (init_declarator_list (init_declarator (declarator (identifier x)) = (initializer (assign_expr (conditional_expression (or_expression (and_expression (inclusive_or_expression (exclusive_or_expression (bit_and_expression (equality_expression (relational_expression (shift_expression (additive_expression (multiplicative_expression (cast_expression (unary_expression (new_expression new (type_name (base_type uint8_t)) [ (conditional_expression (or_expression (and_expression (inclusive_or_expression (exclusive_or_expression (bit_and_expression (equality_expression (relational_expression (shift_expression (additive_expression (multiplicative_expression (cast_expression (unary_expression (postfix_expression (primary_expression (constant 42)))))))))))))))) ]))))))))))))))))) ;)))))", output);
+	}
+
+	@Test
+	public void testDelete() {
+		String input = "delete n;";
+		String output = generateParserOutput(input);
+		assertEquals("(statements (statement (expr_statement (expr (assign_expr (conditional_expression (or_expression (and_expression (inclusive_or_expression (exclusive_or_expression (bit_and_expression (equality_expression (relational_expression (shift_expression (additive_expression (multiplicative_expression (cast_expression (unary_expression (delete_expression delete (identifier n))))))))))))))))) ;)))",
+					 output);
+	}
+
+	@Test
+	public void testArrayDelete() {
+		String input = "delete[] n;";
+		String output = generateParserOutput(input);
+		assertEquals("(statements (statement (expr_statement (expr (assign_expr (conditional_expression (or_expression (and_expression (inclusive_or_expression (exclusive_or_expression (bit_and_expression (equality_expression (relational_expression (shift_expression (additive_expression (multiplicative_expression (cast_expression (unary_expression (delete_expression delete [ ] (identifier n))))))))))))))))) ;)))",
+					 output);
+	}
 }

--- a/src/test/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgTests.scala
+++ b/src/test/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgTests.scala
@@ -921,6 +921,64 @@ class AstToCpgTests extends WordSpec with Matchers {
       val callArgs = call.expandArgument
       callArgs.check(2, x => x.value2[String](NodeKeys.CODE), "x", "count")
     }
+
+    "be correct for 'new' array" in new Fixture(
+      """
+        |int[] alloc(int n) {
+        |   int[] arr = new int[n];
+        |   return arr;
+        |}
+        |""".stripMargin
+    ) {
+      val call = getCall("<operator>.new")
+      call.checkForSingle(NodeKeys.CODE, "new int[n]")
+
+      val callArgs = call.expandArgument
+      callArgs.check(1, x => x.value2[String](NodeKeys.CODE), "int")
+    }
+
+    "be correct for 'new' object" in new Fixture(
+      """
+        |Foo* alloc(int n) {
+        |   Foo* foo = new Foo(n, 42);
+        |   return foo;
+        |}
+        |""".stripMargin
+    ) {
+      val call = getCall("<operator>.new")
+      call.checkForSingle(NodeKeys.CODE, "new Foo(n, 42)")
+
+      val callArgs = call.expandArgument
+      callArgs.check(1, x => x.value2[String](NodeKeys.CODE), "Foo")
+    }
+
+    "be correct for simple 'delete'" in new Fixture(
+      """
+        |int delete_number(int* n) {
+        |  delete n;
+        |}
+        |""".stripMargin
+    ) {
+      val call = getCall("<operator>.delete")
+      call.checkForSingle(NodeKeys.CODE, "delete n")
+
+      val callArgs = call.expandArgument
+      callArgs.check(1, x => x.value2[String](NodeKeys.CODE), "n")
+    }
+
+    "be correct for array 'delete'" in new Fixture(
+      """
+        |void delete_number(int n[]) {
+        |  delete[] n;
+        |}
+        |""".stripMargin
+    ) {
+      val call = getCall("<operator>.delete")
+      call.checkForSingle(NodeKeys.CODE, "delete[] n")
+
+      val callArgs = call.expandArgument
+      callArgs.check(1, x => x.value2[String](NodeKeys.CODE), "n")
+    }
   }
 
   "AST" should {


### PR DESCRIPTION
- Note that only the class type is added as an argument to the `new` call. The class constructor arguments are not added.