### PR TITLE
Emit single Method in presence of function declaration and def.

### DIFF
--- a/src/main/java/io/shiftleft/fuzzyc2cpg/ast/functionDef/FunctionDefBase.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/ast/functionDef/FunctionDefBase.java
@@ -13,7 +13,7 @@ public abstract class FunctionDefBase extends AstNode {
 
   public abstract String getName();
 
-  public abstract String getFunctionSignature();
+  public abstract String getFunctionSignature(boolean includeParameterName);
 
   public ReturnType getReturnType() {
     return returnType;
@@ -52,7 +52,7 @@ public abstract class FunctionDefBase extends AstNode {
 
   @Override
   public String getEscapedCodeStr() {
-    setCodeStr(getFunctionSignature());
+    setCodeStr(getFunctionSignature(true));
     return getCodeStr();
   }
 

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/ast/functionDef/ParameterList.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/ast/functionDef/ParameterList.java
@@ -32,21 +32,23 @@ public class ParameterList extends AstNode implements Iterable<ParameterBase> {
 
   @Override
   public String getEscapedCodeStr() {
+    return getEscapedCodeStr(true);
+  }
 
+  public String getEscapedCodeStr(boolean includeParameterName) {
     if (parameters.size() == 0) {
       setCodeStr("");
       return getCodeStr();
     }
 
-    Iterator<ParameterBase> i = parameters.iterator();
     StringBuilder s = new StringBuilder();
-    for (; i.hasNext(); ) {
-      ParameterBase param = i.next();
-      s.append(param.getEscapedCodeStr() + " , ");
-    }
 
-    setCodeStr(s.toString());
-    setCodeStr(getCodeStr().substring(0, s.length() - 3));
+    parameters.iterator().forEachRemaining(param -> {
+      if (includeParameterName) s.append(param.getEscapedCodeStr()).append(",");
+      else s.append(param.getType().getEscapedCodeStr()).append(",");
+    });
+
+    setCodeStr(s.substring(0, s.length() - 1));
 
     return getCodeStr();
   }

--- a/src/main/java/io/shiftleft/fuzzyc2cpg/ast/langc/functiondef/FunctionDef.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/ast/langc/functiondef/FunctionDef.java
@@ -29,14 +29,15 @@ public class FunctionDef extends FunctionDefBase {
   }
 
   @Override
-  public String getFunctionSignature() {
-    String retval = getIdentifier().getEscapedCodeStr();
+  public String getFunctionSignature(boolean includeParameterName) {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getIdentifier().getEscapedCodeStr());
     if (getParameterList() != null) {
-      retval += " (" + getParameterList().getEscapedCodeStr() + ")";
+      sb.append(" (").append(getParameterList().getEscapedCodeStr(includeParameterName)).append(")");
     } else {
-      retval += " ()";
+      sb.append(" ()");
     }
-    return retval;
+    return sb.toString();
   }
 
   @Override

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/AstVisitor.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/AstVisitor.scala
@@ -45,9 +45,9 @@ class AstVisitor(outputModuleFactory: CpgOutputModuleFactory, structureCpg: CpgS
       // corresponding definition, in which case the declaration will be
       // removed again and is never persisted. Persisting of declarations
       // happens after concurrent processing of compilation units.
-      FuzzyC2CpgCache.add(functionDef.getFunctionSignature, outputIdentifier, bodyCpg)
+      FuzzyC2CpgCache.add(functionDef.getFunctionSignature(false), outputIdentifier, bodyCpg)
     } else {
-      FuzzyC2CpgCache.remove(functionDef.getFunctionSignature)
+      FuzzyC2CpgCache.remove(functionDef.getFunctionSignature(false))
       outputModule.persistCpg(bodyCpg)
     }
   }

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
@@ -211,7 +211,7 @@ object FuzzyC2CpgCache {
     * */
   def remove(signature: String): Unit = {
     functionDeclarations.synchronized {
-      functionDeclarations.put(signature, mutable.ListBuffer())
+      functionDeclarations.remove(signature)
     }
   }
 

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgConverter.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgConverter.scala
@@ -125,10 +125,12 @@ class AstToCpgConverter[NodeBuilderType, NodeType, EdgeBuilderType, EdgeType](
     } else {
       "int"
     }
-    val signature = returnType +
-      astFunction.getParameterList.asScala
-        .map(_.getType.getEscapedCodeStr)
-        .mkString("(", ",", ")")
+    val signature = new StringBuilder()
+      .append(returnType)
+      .append("(")
+      .append(astFunction.getParameterList.getEscapedCodeStr(false))
+      .append(")").toString()
+
     val cpgMethod = adapter
       .createNodeBuilder(NodeKind.METHOD)
       .addProperty(NodeProperty.NAME, astFunction.getName)

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgConverter.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgConverter.scala
@@ -129,7 +129,8 @@ class AstToCpgConverter[NodeBuilderType, NodeType, EdgeBuilderType, EdgeType](
       .append(returnType)
       .append("(")
       .append(astFunction.getParameterList.getEscapedCodeStr(false))
-      .append(")").toString()
+      .append(")")
+      .toString()
 
     val cpgMethod = adapter
       .createNodeBuilder(NodeKind.METHOD)

--- a/src/test/java/io/shiftleft/fuzzyc2cpg/parsetreetoast/ModuleBuildersTest.java
+++ b/src/test/java/io/shiftleft/fuzzyc2cpg/parsetreetoast/ModuleBuildersTest.java
@@ -148,7 +148,7 @@ public class ModuleBuildersTest
 		List<AstNode> codeItems = parseInput(input);
 		FunctionDefBase codeItem = (FunctionDefBase) codeItems.get(0);
 		assertTrue(codeItem.getEscapedCodeStr()
-				.equals("foo (int x , char **ptr)"));
+				.equals("foo (int x,char **ptr)"));
 	}
 
 	@Test
@@ -168,7 +168,7 @@ public class ModuleBuildersTest
 		List<AstNode> codeItems = parseInput(input);
 		FunctionDefBase codeItem = (FunctionDefBase) codeItems.get(0);
 		String codeStr = codeItem.getParameterList().getEscapedCodeStr();
-		assertTrue(codeStr.equals("char *myParam , myType x"));
+		assertTrue(codeStr.equals("char *myParam,myType x"));
 	}
 
 	@Test

--- a/src/test/resources/testcode/methoddecl/methoddecl.c
+++ b/src/test/resources/testcode/methoddecl/methoddecl.c
@@ -1,0 +1,4 @@
+int add(int, int);
+int add(int x, int y) {
+    return x + y;
+}

--- a/src/test/scala/io/shiftleft/fuzzyc2cpg/MethodDeclTest.scala
+++ b/src/test/scala/io/shiftleft/fuzzyc2cpg/MethodDeclTest.scala
@@ -1,0 +1,22 @@
+package io.shiftleft.fuzzyc2cpg
+
+import org.scalatest.{Matchers, WordSpec}
+
+import io.shiftleft.codepropertygraph.generated.{NodeKeys, NodeTypes}
+
+class MethodDeclTest extends WordSpec with Matchers {
+
+  private val fixture = CpgTestFixture("methoddecl")
+
+  "MethodDeclTest" should {
+    "omit the method declaration in presence of a definition" in {
+      val result = fixture.V
+        .hasLabel(NodeTypes.METHOD)
+        .l
+
+      result.size shouldBe 1
+      val signature = result.head.property[String](NodeKeys.SIGNATURE.name).value
+      signature shouldBe "int(int,int)"
+    }
+  }
+}


### PR DESCRIPTION
Two Method nodes would be emitted for a single function if the function declaration and definition arguments were omitted or differed in names.

To fix the issue, parameter names are now ignored when checking function definition signatures against declaration signatures.