### PR TITLE
Omit generation of METHOD_INST nodes.

### DIFF
--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgConverter.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgConverter.scala
@@ -867,17 +867,9 @@ class AstToCpgConverter[NodeBuilderType, NodeType, EdgeBuilderType, EdgeType](
       .addProperty(NodeProperty.DISPATCH_TYPE, DispatchTypes.STATIC_DISPATCH.name())
       .addProperty(NodeProperty.SIGNATURE, "TODO assignment signature")
       .addProperty(NodeProperty.TYPE_FULL_NAME, registerType(Defines.anyTypeName))
-      .addProperty(NodeProperty.METHOD_INST_FULL_NAME, methodName)
+      .addProperty(NodeProperty.METHOD_FULL_NAME, methodName)
       .addCommons(astNode, context)
       .createNode(astNode)
-
-    adapter
-      .createNodeBuilder(NodeKind.METHOD_INST)
-      .addProperty(NodeProperty.NAME, methodName)
-      .addProperty(NodeProperty.FULL_NAME, methodName)
-      .addProperty(NodeProperty.SIGNATURE, "TODO assignment signature")
-      .addProperty(NodeProperty.METHOD_FULL_NAME, methodName)
-      .createNode()
 
     cpgNode
   }


### PR DESCRIPTION
The `METHOD_FULL_NAME` attribute is now set on all `Call` nodes when generating the CPG. This will allow us to remove the `MethodInstCompat` pass in Joern and Ocular.