### PR TITLE
Write out declarations in parallel

### DIFF
--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
@@ -86,7 +86,7 @@ class FuzzyC2Cpg(outputModuleFactory: CpgOutputModuleFactory) {
   }
 
   private def addFunctionDeclarations(): Unit = {
-    FuzzyC2CpgCache.sortedSignatures.foreach { signature =>
+    FuzzyC2CpgCache.sortedSignatures.par.foreach { signature =>
       FuzzyC2CpgCache.getDeclarations(signature).foreach {
         case (outputIdentifier, bodyCpg) =>
           val outputModule = outputModuleFactory.create()


### PR DESCRIPTION
While we were writing out functions in parallel, we did not do so for declarations. For large code bases, this could be a performance bottleneck.

*Update*: confirmed that this saves us over a minute on parsing blender.