### PR TITLE
Wait for writer thread to finish

### DIFF
--- a/src/main/java/io/shiftleft/fuzzyc2cpg/output/overflowdb/OutputModuleFactory.scala
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/output/overflowdb/OutputModuleFactory.scala
@@ -11,7 +11,8 @@ class OutputModuleFactory(outputPath: String, queue: BlockingQueue[CpgStruct.Bui
 
   private val logger = LoggerFactory.getLogger(getClass)
   private val writer = new OverflowDbWriter(outputPath, queue)
-  new Thread(writer).start()
+  val writerThread = new Thread(writer)
+  writerThread.start()
 
   override def create(): CpgOutputModule = new OutputModule(queue)
 
@@ -22,5 +23,6 @@ class OutputModuleFactory(outputPath: String, queue: BlockingQueue[CpgStruct.Bui
     } catch {
       case _: InterruptedException => logger.warn("Interrupted during persist operation")
     }
+    writerThread.join()
   }
 }


### PR DESCRIPTION
When using `--overflowdb` via the command line, we naturally wait for the writer thread to finish, however, when using `FuzzyC2Cpg's` with the new overflowdb output module programmatically, we need to call `writerThread.join` for correct operation.