### PR TITLE
use official cpg release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ organization := "io.shiftleft"
 scalaVersion := "2.13.1"
 enablePlugins(GitVersioning)
 
-val cpgVersion = "0.11.188+10-44a539fa"
+val cpgVersion = "0.11.189"
 val antlrVersion = "4.7.2"
 
 libraryDependencies ++= Seq(


### PR DESCRIPTION
i had to merge the previous PR this despite a dependency on an unofficial cpg release - that's the price for having a circular dependency cpg <-> fuzzyc