### PR TITLE
Catch StackOverflow

### DIFF
--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
@@ -167,6 +167,10 @@ class FuzzyC2Cpg(outputModuleFactory: CpgOutputModuleFactory) {
         logger.warn("Complete exception: ", ex)
         return
       }
+      case ex: StackOverflowError => {
+        logger.warn("Cannot parse module: " + filename + ", skipping, StackOverflow")
+        return
+      }
     }
 
     val outputModule = outputModuleFactory.create()


### PR DESCRIPTION
ANTLR can throw StackOverflow exceptions (see https://github.com/antlr/antlr4/issues/1943) and this seems to also not change when upgrading to ANTLR 4.8. We've usually seen this when parsing deeply nested structures defined in header files. For now, let's at least not crash entirely and instead only skip the affected file as we generally do when we can't parse something.