### PR TITLE
Make goto/continue/break/throw control structures

### DIFF
--- a/src/main/java/io/shiftleft/fuzzyc2cpg/ast/statements/jump/GotoStatement.java
+++ b/src/main/java/io/shiftleft/fuzzyc2cpg/ast/statements/jump/GotoStatement.java
@@ -1,21 +1,9 @@
 package io.shiftleft.fuzzyc2cpg.ast.statements.jump;
 
-import io.shiftleft.fuzzyc2cpg.ast.expressions.StringExpression;
 import io.shiftleft.fuzzyc2cpg.ast.logical.statements.JumpStatement;
 import io.shiftleft.fuzzyc2cpg.ast.walking.ASTNodeVisitor;
 
 public class GotoStatement extends JumpStatement {
-
-  private StringExpression label = null;
-
-  public StringExpression getTargetLabel() {
-    return this.label;
-  }
-
-  public void setTargetLabel(StringExpression label) {
-    this.label = label;
-    super.addChild(label);
-  }
 
   public String getTargetName() {
     // TODO since C world does not use the setTargetLabel() method but

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgConverter.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgConverter.scala
@@ -530,7 +530,7 @@ class AstToCpgConverter[NodeBuilderType, NodeType, EdgeBuilderType, EdgeType](
   }
 
   override def visit(astThrow: ThrowStatement): Unit = {
-    val cpgThrow = newUnknownNode(astThrow)
+    val cpgThrow = newControlStructureNode(astThrow)
 
     addAstChild(cpgThrow)
 

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgConverter.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgConverter.scala
@@ -401,21 +401,15 @@ class AstToCpgConverter[NodeBuilderType, NodeType, EdgeBuilderType, EdgeType](
   }
 
   override def visit(astBreak: BreakStatement): Unit = {
-    val cpgBreak = newUnknownNode(astBreak)
-
-    addAstChild(cpgBreak)
+    addAstChild(newControlStructureNode(astBreak))
   }
 
   override def visit(astContinue: ContinueStatement): Unit = {
-    val cpgContinue = newUnknownNode(astContinue)
-
-    addAstChild(cpgContinue)
+    addAstChild(newControlStructureNode(astContinue))
   }
 
   override def visit(astGoto: GotoStatement): Unit = {
-    val cpgGoto = newUnknownNode(astGoto)
-
-    addAstChild(cpgGoto)
+    addAstChild(newControlStructureNode(astGoto))
   }
 
   override def visit(astIdentifier: Identifier): Unit = {


### PR DESCRIPTION
Previously, we created nodes of type `UNKNOWN` for `goto`, `continue`, `break`, and `throw` instead of CONTROL_STRUCTURE. I believe this is because we introduced CONTROL_STRUCTURE at a later point and for the sole purpose of querying nested code.