### PR TITLE
Set `code` field for JUMP_TARGET and METHOD

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ organization := "io.shiftleft"
 scalaVersion := "2.13.1"
 enablePlugins(GitVersioning)
 
-val cpgVersion = "0.11.266"
+val cpgVersion = "0.11.276"
 val antlrVersion = "4.7.2"
 
 libraryDependencies ++= Seq(

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgConverter.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgConverter.scala
@@ -135,6 +135,7 @@ class AstToCpgConverter[NodeBuilderType, NodeType, EdgeBuilderType, EdgeType](
     val cpgMethod = adapter
       .createNodeBuilder(NodeKind.METHOD)
       .addProperty(NodeProperty.NAME, astFunction.getName)
+      .addProperty(NodeProperty.CODE, astFunction.getEscapedCodeStr)
       .addProperty(NodeProperty.IS_EXTERNAL, value = false)
       .addProperty(NodeProperty.FULL_NAME, value = s"${astFunction.getName}")
       .addProperty(NodeProperty.LINE_NUMBER, astFunction.getLocation.startLine)
@@ -690,6 +691,7 @@ class AstToCpgConverter[NodeBuilderType, NodeType, EdgeBuilderType, EdgeType](
       .createNodeBuilder(NodeKind.JUMP_TARGET)
       .addProperty(NodeProperty.PARSER_TYPE_NAME, astLabel.getClass.getSimpleName)
       .addProperty(NodeProperty.NAME, astLabel.getLabelName)
+      .addProperty(NodeProperty.CODE, astLabel.getEscapedCodeStr)
       .addCommons(astLabel, context)
       .createNode(astLabel)
     addAstChild(cpgLabel)

--- a/src/test/scala/io/shiftleft/fuzzyc2cpg/MethodHeaderTests.scala
+++ b/src/test/scala/io/shiftleft/fuzzyc2cpg/MethodHeaderTests.scala
@@ -19,6 +19,7 @@ class MethodHeaderTests extends WordSpec with Matchers {
       methods.head.value2(NodeKeys.COLUMN_NUMBER) shouldBe 0
       methods.head.value2(NodeKeys.LINE_NUMBER_END) shouldBe 3
       methods.head.value2(NodeKeys.COLUMN_NUMBER_END) shouldBe 0
+      methods.head.value2(NodeKeys.CODE) shouldBe "foo (int x,int y)"
     }
 
     "have correct METHOD_PARAMETER_IN nodes for method foo" in {

--- a/src/test/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgTests.scala
+++ b/src/test/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgTests.scala
@@ -879,6 +879,11 @@ class AstToCpgTests extends WordSpec with Matchers {
       callArgs.checkForSingle(NodeKeys.CODE, "int")
     }
 
+    "be correct for label" in new Fixture("foo() { label: }") {
+      val jumpTarget = getVertices("label", NodeTypes.JUMP_TARGET)
+      jumpTarget.checkForSingle(NodeKeys.CODE, "label:")
+    }
+
     "be correct for array indexing" in new Fixture(
       """
         |int head(int x[]) {


### PR DESCRIPTION
Re: https://github.com/ShiftLeftSecurity/codepropertygraph/pull/803