### PR TITLE
Stable node ids

### DIFF
--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/AstVisitor.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/AstVisitor.scala
@@ -20,7 +20,8 @@ import org.antlr.v4.runtime.ParserRuleContext
 class AstVisitor(outputModuleFactory: CpgOutputModuleFactory,
                  structureCpg: CpgStruct.Builder,
                  astParentNode: Node,
-                 keyPool: KeyPool)
+                 keyPool: KeyPool,
+                 cache: FuzzyC2CpgCache)
     extends ASTNodeVisitor
     with AntlrParserDriverObserver {
   private var fileNameOption = Option.empty[String]
@@ -49,9 +50,9 @@ class AstVisitor(outputModuleFactory: CpgOutputModuleFactory,
       // corresponding definition, in which case the declaration will be
       // removed again and is never persisted. Persisting of declarations
       // happens after concurrent processing of compilation units.
-      FuzzyC2CpgCache.add(functionDef.getFunctionSignature(false), outputIdentifier, bodyCpg)
+      cache.add(functionDef.getFunctionSignature(false), outputIdentifier, bodyCpg)
     } else {
-      FuzzyC2CpgCache.remove(functionDef.getFunctionSignature(false))
+      cache.remove(functionDef.getFunctionSignature(false))
       outputModule.persistCpg(bodyCpg)
     }
   }

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/AstVisitor.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/AstVisitor.scala
@@ -18,7 +18,6 @@ import io.shiftleft.proto.cpg.Cpg.CpgStruct.Node
 import org.antlr.v4.runtime.ParserRuleContext
 
 class AstVisitor(outputModuleFactory: CpgOutputModuleFactory,
-                 structureCpg: CpgStruct.Builder,
                  astParentNode: Node,
                  keyPool: KeyPool,
                  cache: FuzzyC2CpgCache,
@@ -26,6 +25,7 @@ class AstVisitor(outputModuleFactory: CpgOutputModuleFactory,
     extends ASTNodeVisitor
     with AntlrParserDriverObserver {
   private var fileNameOption = Option.empty[String]
+  private val structureCpg = CpgStruct.newBuilder()
 
   /**
     * Callback triggered for each function definition
@@ -86,7 +86,12 @@ class AstVisitor(outputModuleFactory: CpgOutputModuleFactory,
     fileNameOption = Some(filename)
   }
 
-  override def endOfUnit(ctx: ParserRuleContext, filename: String): Unit = {}
+  override def endOfUnit(ctx: ParserRuleContext, filename: String): Unit = {
+    val identifier = s"$filename types"
+    val outputModule = outputModuleFactory.create()
+    outputModule.setOutputIdentifier(identifier)
+    outputModule.persistCpg(structureCpg)
+  }
 
   override def processItem[T <: AstNode](node: T, builderStack: util.Stack[AstNodeBuilder[_ <: AstNode]]): Unit = {
     node.accept(this)

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/AstVisitor.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/AstVisitor.scala
@@ -21,7 +21,8 @@ class AstVisitor(outputModuleFactory: CpgOutputModuleFactory,
                  structureCpg: CpgStruct.Builder,
                  astParentNode: Node,
                  keyPool: KeyPool,
-                 cache: FuzzyC2CpgCache)
+                 cache: FuzzyC2CpgCache,
+                 global: Global)
     extends ASTNodeVisitor
     with AntlrParserDriverObserver {
   private var fileNameOption = Option.empty[String]
@@ -38,7 +39,7 @@ class AstVisitor(outputModuleFactory: CpgOutputModuleFactory,
     val bodyCpg = CpgStruct.newBuilder()
     val cpgAdapter = new ProtoCpgAdapter(bodyCpg, keyPool)
     val astToCpgConverter =
-      new AstToCpgConverter(astParentNode, cpgAdapter)
+      new AstToCpgConverter(astParentNode, cpgAdapter, global)
     astToCpgConverter.convert(functionDef)
 
     val astToCfgConverter =
@@ -63,7 +64,7 @@ class AstVisitor(outputModuleFactory: CpgOutputModuleFactory,
   override def visit(classDefStatement: ClassDefStatement): Unit = {
     val cpgAdapter = new ProtoCpgAdapter(structureCpg, keyPool)
     val astToCpgConverter =
-      new AstToCpgConverter(astParentNode, cpgAdapter)
+      new AstToCpgConverter(astParentNode, cpgAdapter, global)
     astToCpgConverter.convert(classDefStatement)
   }
 
@@ -73,7 +74,7 @@ class AstVisitor(outputModuleFactory: CpgOutputModuleFactory,
   override def visit(identifierDeclStmt: IdentifierDeclStatement): Unit = {
     val cpgAdapter = new ProtoCpgAdapter(structureCpg, keyPool)
     val astToCpgConverter =
-      new AstToCpgConverter(astParentNode, cpgAdapter)
+      new AstToCpgConverter(astParentNode, cpgAdapter, global)
     astToCpgConverter.convert(identifierDeclStmt)
   }
 

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
@@ -197,13 +197,12 @@ class FuzzyC2Cpg(outputModuleFactory: CpgOutputModuleFactory) {
     // receive callbacks as we walk the tree. The method body parser
     // will the invoked by `astVisitor` as we walk the tree
 
-    val cpg = CpgStruct.newBuilder
     val driver = new AntlrCModuleParserDriver()
     val astVisitor =
-      new AstVisitor(outputModuleFactory, cpg, namespaceBlock, keyPool, cache, global)
+      new AstVisitor(outputModuleFactory, namespaceBlock, keyPool, cache, global)
     driver.addObserver(astVisitor)
-    driver.setCpg(cpg)
     driver.setKeyPool(keyPool)
+    driver.setOutputModuleFactory(outputModuleFactory)
     driver.setFileNode(fileNode)
 
     try {
@@ -212,19 +211,11 @@ class FuzzyC2Cpg(outputModuleFactory: CpgOutputModuleFactory) {
       case ex: RuntimeException => {
         logger.warn("Cannot parse module: " + filename + ", skipping")
         logger.warn("Complete exception: ", ex)
-        return
       }
       case _: StackOverflowError => {
         logger.warn("Cannot parse module: " + filename + ", skipping, StackOverflow")
-        return
       }
     }
-
-    val outputModule = outputModuleFactory.create()
-    outputModule.setOutputIdentifier(
-      s"$filename types"
-    )
-    outputModule.persistCpg(cpg)
   }
 
 }

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
@@ -82,11 +82,11 @@ class FuzzyC2Cpg(outputModuleFactory: CpgOutputModuleFactory) {
     outputModule.persistCpg(cpg)
 
     // TODO improve fuzzyc2cpg namespace support. Currently, everything
-    // is in the same global namespace so the code below is correctly.
+    // is in the same global namespace so the code below is correct.
     sourceFileNames.zipWithIndex
       .map { case (filename, i) => (filename, keyPools(i + 1)) }
       .par
-      .foreach(createCpgForCompilationUnit)
+      .foreach { case (filename, keyPool) => createCpgForCompilationUnit(filename, keyPool) }
     addFunctionDeclarations()
     outputModuleFactory.persist()
   }
@@ -151,10 +151,7 @@ class FuzzyC2Cpg(outputModuleFactory: CpgOutputModuleFactory) {
     addAnyTypeAndNamespaceBlock(cpg)
   }
 
-  case class NodesForFile(fileNode: CpgStruct.Node, namespaceBlockNode: CpgStruct.Node) {}
-
-  private def createCpgForCompilationUnit(filenameAndKeyPool: (String, KeyPool)): Unit = {
-    val (filename, keyPool) = filenameAndKeyPool
+  private def createCpgForCompilationUnit(filename: String, keyPool: KeyPool): Unit = {
     val (fileNode, namespaceBlock) = fileAndNamespaceGraph(filename, keyPool)
 
     // We call the module parser here and register the `astVisitor` to

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/KeyPools.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/KeyPools.scala
@@ -1,0 +1,21 @@
+package io.shiftleft.fuzzyc2cpg
+
+import io.shiftleft.passes.KeyPool
+
+object KeyPools {
+
+  /**
+    * Divide the keyspace into n intervals and return
+    * a list of corresponding key pools.
+    * */
+  def obtain(n: Long, maxValue: Long = Long.MaxValue): List[KeyPool] = {
+    val nIntervals = Math.max(n, 1)
+    val intervalLen: Long = maxValue / nIntervals
+    List.range(0, nIntervals).map { i =>
+      val first = i * intervalLen
+      val last = first + intervalLen - 1
+      new KeyPool(first, last)
+    }
+  }
+
+}

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/SourceFiles.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/SourceFiles.scala
@@ -8,7 +8,7 @@ object SourceFiles {
     * For a given array of input paths, determine all C/C++
     * source files by inspecting filename extensions.
     * */
-  def determine(inputPaths: Set[String], sourceFileExtensions: Set[String]): Set[String] = {
+  def determine(inputPaths: Set[String], sourceFileExtensions: Set[String]): List[String] = {
     def hasSourceFileExtension(file: File): Boolean =
       file.extension.exists(sourceFileExtensions.contains)
 
@@ -21,6 +21,6 @@ object SourceFiles {
       .flatMap(_.listRecursively.filter(hasSourceFileExtension))
       .map(_.toString)
 
-    matchingFiles ++ matchingFilesFromDirs
+    (matchingFiles ++ matchingFilesFromDirs).toList.sorted
   }
 }

--- a/src/test/resources/testcode/stableid/file1.c
+++ b/src/test/resources/testcode/stableid/file1.c
@@ -1,6 +1,10 @@
 
 int y;
 
+struct file1_struct {
+  int member;
+};
+
 void stub_in_file1();
 
 int func_in_file1(int param) {

--- a/src/test/resources/testcode/stableid/file1.c
+++ b/src/test/resources/testcode/stableid/file1.c
@@ -1,0 +1,8 @@
+
+int y;
+
+void stub_in_file1();
+
+int func_in_file1(int param) {
+  return 1;
+}

--- a/src/test/resources/testcode/stableid/file2.c
+++ b/src/test/resources/testcode/stableid/file2.c
@@ -1,0 +1,11 @@
+
+int x;
+
+int func_in_file2(int param) {
+  return 2;
+}
+
+void stub_in_file2();
+
+// Declaration of function available in the other file
+int func_in_file1(int param);

--- a/src/test/scala/io/shiftleft/fuzzyc2cpg/StableOutputTests.scala
+++ b/src/test/scala/io/shiftleft/fuzzyc2cpg/StableOutputTests.scala
@@ -1,0 +1,37 @@
+package io.shiftleft.fuzzyc2cpg
+
+import io.shiftleft.fuzzyc2cpg.output.inmemory.OutputModuleFactory
+import org.scalatest.{Matchers, WordSpec}
+
+import scala.jdk.CollectionConverters._
+
+class StableOutputTests extends WordSpec with Matchers {
+
+  def createNodeStrings(): String = {
+    val projectName = "stableid"
+    val dirName = String.format("src/test/resources/testcode/%s", projectName)
+    val inmemoryOutputFactory = new OutputModuleFactory()
+    val fuzzyc2Cpg = new FuzzyC2Cpg(inmemoryOutputFactory)
+    fuzzyc2Cpg.runAndOutput(Set(dirName), Set(".c", ".cc", ".cpp", ".h", ".hpp"))
+    val cpg = inmemoryOutputFactory.getInternalGraph
+    val nodes = cpg.graph.V().asScala.toList
+    nodes.sortBy(_.id2()).map(x => x.label + ": " + x.propertyMap().asScala.toString).mkString("\n")
+  }
+
+  "Nodes in test graph" should {
+    "should be exactly the same on ten consecutive runs" in {
+      val nodes = List
+        .range(0, 10)
+        .map { _ =>
+          createNodeStrings()
+        }
+        .distinct
+
+      nodes.foreach { n =>
+        println(n)
+        println("===")
+      }
+    }
+  }
+
+}

--- a/src/test/scala/io/shiftleft/fuzzyc2cpg/StableOutputTests.scala
+++ b/src/test/scala/io/shiftleft/fuzzyc2cpg/StableOutputTests.scala
@@ -20,17 +20,13 @@ class StableOutputTests extends WordSpec with Matchers {
 
   "Nodes in test graph" should {
     "should be exactly the same on ten consecutive runs" in {
-      val nodes = List
+      List
         .range(0, 10)
         .map { _ =>
           createNodeStrings()
         }
         .distinct
-
-      nodes.foreach { n =>
-        println(n)
-        println("===")
-      }
+        .size shouldBe 1
     }
   }
 

--- a/src/test/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgTests.scala
+++ b/src/test/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgTests.scala
@@ -127,7 +127,7 @@ class AstToCpgTests extends WordSpec with Matchers {
     protected val astParent = List(astParentNode)
     private val cpgAdapter = new GraphAdapter(graph)
 
-    val global = new Global()
+    val global = Global()
     nodes.foreach { node =>
       val astToProtoConverter = new AstToCpgConverter(astParentNode, cpgAdapter, global)
       astToProtoConverter.convert(node)

--- a/src/test/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgTests.scala
+++ b/src/test/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgTests.scala
@@ -4,9 +4,8 @@ import gremlin.scala._
 import org.antlr.v4.runtime.{CharStreams, ParserRuleContext}
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph
 import org.scalatest.{Matchers, WordSpec}
-
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeKeys, NodeTypes, Operators}
-import io.shiftleft.fuzzyc2cpg.ModuleLexer
+import io.shiftleft.fuzzyc2cpg.{Global, ModuleLexer}
 import io.shiftleft.fuzzyc2cpg.adapter.CpgAdapter
 import io.shiftleft.fuzzyc2cpg.adapter.EdgeKind.EdgeKind
 import io.shiftleft.fuzzyc2cpg.adapter.EdgeProperty.EdgeProperty
@@ -128,8 +127,9 @@ class AstToCpgTests extends WordSpec with Matchers {
     protected val astParent = List(astParentNode)
     private val cpgAdapter = new GraphAdapter(graph)
 
+    val global = new Global()
     nodes.foreach { node =>
-      val astToProtoConverter = new AstToCpgConverter(astParentNode, cpgAdapter)
+      val astToProtoConverter = new AstToCpgConverter(astParentNode, cpgAdapter, global)
       astToProtoConverter.convert(node)
     }
 


### PR DESCRIPTION
This PR introduces the necessary changes to obtain stable node ids and brings us closer to make FuzzyC an example for x2cpg usage.
* As compilation units are processed in parallel, each obtains its own key pool
* Type usages (as indicated by `TYPE` nodes) are first collected across compilation units, then sorted and emitted
* Apart from the fake global namespace (outside of any file), files and namespaces are created independently for compilation units.
* Also fixes a bug in the processing of method declarations: these were reported too often in the past.
* Make the FuzzyCCache a class as opposed to a single object to allow multiple runs of FuzzyC without having to clear a global cache.