### PR TITLE
StubRemovalPass

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ organization := "io.shiftleft"
 scalaVersion := "2.13.1"
 enablePlugins(GitVersioning)
 
-val cpgVersion = "0.11.332+2-737aa7d9"
+val cpgVersion = "0.11.334"
 val antlrVersion = "4.7.2"
 
 libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ organization := "io.shiftleft"
 scalaVersion := "2.13.1"
 enablePlugins(GitVersioning)
 
-val cpgVersion = "0.11.331"
+val cpgVersion = "0.11.332+2-737aa7d9"
 val antlrVersion = "4.7.2"
 
 libraryDependencies ++= Seq(

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/passes/StubRemovalPass.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/passes/StubRemovalPass.scala
@@ -1,0 +1,21 @@
+package io.shiftleft.fuzzyc2cpg.passes
+
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.passes.{DiffGraph, ParallelCpgPass}
+import io.shiftleft.semanticcpg.language._
+import io.shiftleft.codepropertygraph.generated.nodes
+
+class StubRemovalPass(cpg: Cpg) extends ParallelCpgPass[nodes.Method](cpg) {
+  override def partIterator: Iterator[nodes.Method] =
+    cpg.method.isNotStub.iterator
+
+  override def runOnPart(method: nodes.Method): Iterator[DiffGraph] = {
+    val diffGraph = DiffGraph.newBuilder
+    cpg.method.isStub.where(m => m.signature == method.signature).foreach { stubMethod =>
+      stubMethod.ast.l.foreach { node =>
+        diffGraph.removeNode(node.id2())
+      }
+    }
+    Iterator(diffGraph.build)
+  }
+}

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/passes/StubRemovalPass.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/passes/StubRemovalPass.scala
@@ -5,6 +5,10 @@ import io.shiftleft.passes.{DiffGraph, ParallelCpgPass}
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.codepropertygraph.generated.nodes
 
+/**
+  * A pass that ensures that for any method m for which a body exists,
+  * there are no more method stubs for corresponding declarations.
+  * */
 class StubRemovalPass(cpg: Cpg) extends ParallelCpgPass[nodes.Method](cpg) {
   override def partIterator: Iterator[nodes.Method] =
     cpg.method.isNotStub.iterator

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/passes/astcreation/AstCreator.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/passes/astcreation/AstCreator.scala
@@ -103,12 +103,8 @@ private[astcreation] class AstCreator(diffGraph: DiffGraph.Builder,
     } else {
       "int"
     }
-    val signature = new StringBuilder()
-      .append(returnType)
-      .append("(")
-      .append(astFunction.getParameterList.getEscapedCodeStr(false))
-      .append(")")
-      .toString()
+
+    val signature = astFunction.getFunctionSignature(false)
 
     val location = astFunction.getLocation
     val method = nodes.NewMethod(

--- a/src/test/scala/io/shiftleft/fuzzyc2cpg/passes/StubRemovalPassTests.scala
+++ b/src/test/scala/io/shiftleft/fuzzyc2cpg/passes/StubRemovalPassTests.scala
@@ -1,0 +1,5 @@
+package io.shiftleft.fuzzyc2cpg.passes
+
+import org.scalatest.{Matchers, WordSpec}
+
+class StubRemovalPassTests extends WordSpec with Matchers {}

--- a/src/test/scala/io/shiftleft/fuzzyc2cpg/passes/StubRemovalPassTests.scala
+++ b/src/test/scala/io/shiftleft/fuzzyc2cpg/passes/StubRemovalPassTests.scala
@@ -1,5 +1,64 @@
 package io.shiftleft.fuzzyc2cpg.passes
 
+import better.files.File
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.passes.IntervalKeyPool
 import org.scalatest.{Matchers, WordSpec}
+import io.shiftleft.semanticcpg.language._
 
-class StubRemovalPassTests extends WordSpec with Matchers {}
+class StubRemovalPassTests extends WordSpec with Matchers {
+
+  "StubRemovalPass" should {
+    "remove stub if non-stub with same signature exists" in StubRemovalPassFixture("""
+        |int foo(int x);
+        |int foo(int x) {
+        | return 0;
+        |}
+        |""".stripMargin) { cpg =>
+      cpg.method.name.l shouldBe List("foo")
+      cpg.method.isStub.l shouldBe List()
+      cpg.parameter.name.l shouldBe List("x")
+      cpg.methodReturn.l.size shouldBe 1
+    }
+
+    "remove stub even if even parameter names differ" in StubRemovalPassFixture("""
+        |int foo(int another_name);
+        |int foo(int x) {
+        | return 0;
+        |}
+        |""".stripMargin) { cpg =>
+      cpg.method.name.l shouldBe List("foo")
+      cpg.method.isStub.l shouldBe List()
+      cpg.parameter.name.l shouldBe List("x")
+      cpg.methodReturn.l.size shouldBe 1
+    }
+
+    "keep multiple implementations" in StubRemovalPassFixture("""
+        |int foo(int x) { return x; }
+        |int foo(int x) {
+        | return 0;
+        |}
+        |""".stripMargin) { cpg =>
+      cpg.method.name.l shouldBe List("foo", "foo")
+    }
+
+  }
+
+}
+
+object StubRemovalPassFixture {
+  def apply(file1Code: String)(f: Cpg => Unit): Unit = {
+    File.usingTemporaryDirectory("fuzzyctest") { dir =>
+      val file1 = (dir / "file1.c")
+      file1.write(file1Code)
+      val cpg = Cpg.emptyCpg
+      val keyPool = new IntervalKeyPool(1001, 2000)
+      val filenames = List(file1.path.toAbsolutePath.toString)
+      new AstCreationPass(filenames, cpg, keyPool).createAndApply()
+      val cfgKeyPool = new IntervalKeyPool(2001, 3000)
+      new CfgCreationPass(cpg, cfgKeyPool).createAndApply()
+      new StubRemovalPass(cpg).createAndApply()
+      f(cpg)
+    }
+  }
+}


### PR DESCRIPTION
Depends on: https://github.com/ShiftLeftSecurity/codepropertygraph/pull/859

During AST/CFG construction, we used to not write declarations into the graph immediately, but rather we deferred this to check whether we would later encounter a definition for the same method. This meant that we had to keep a potentially large cache of declarations as we were constructing CPGs.

In the passes-based approach, we can now run a pass that removes lone stubs for methods with definitions, once all code has been imported. We could even run this as part of the C-specific enhancements later. This PR brings in this new pass + tests.