### PR TITLE
Fix concurrency issue when registering types

### DIFF
--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgConverter.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/astnew/AstToCpgConverter.scala
@@ -884,7 +884,7 @@ class AstToCpgConverter[NodeBuilderType, NodeType, EdgeBuilderType, EdgeType](
   }
 
   private def registerType(typeName: String): String = {
-    global.usedTypes += typeName
+    global.usedTypes.put(typeName, true)
     typeName
   }
 

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/passes/astcreation/AstCreator.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/passes/astcreation/AstCreator.scala
@@ -849,7 +849,7 @@ private[astcreation] class AstCreator(diffGraph: DiffGraph.Builder,
   }
 
   private def registerType(typeName: String): String = {
-    global.usedTypes += typeName
+    global.usedTypes.put(typeName, true)
     typeName
   }
 


### PR DESCRIPTION
In a recent refactor, I must have replaced ConcurrentHashMap by a simple mutable scala set, and that lead to slight fluctuations in the number of `TYPE` nodes emitted. This PR fixes this issue by bringing back ConcurrentHashMap.