### PR TITLE
Include `JumpTarget` nodes in the CFG

### DIFF
--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/passes/CfgCreationPass.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/passes/CfgCreationPass.scala
@@ -166,7 +166,7 @@ class CfgCreatorForMethod(entryNode: nodes.Method) {
     if (labelName.startsWith("case") || labelName.startsWith("default")) {
       // Under normal conditions this is always true.
       // But if the parser missed a switch statement, caseStack
-      // might by empty.
+      // might be empty.
       if (caseStack.numberOfLayers > 0) {
         caseStack.store(n)
       }
@@ -216,7 +216,7 @@ class CfgCreatorForMethod(entryNode: nodes.Method) {
     extendCfg(node)
     // Under normal conditions this is always true.
     // But if the parser missed a loop or switch statement, breakStack
-    // might by empty.
+    // might be empty.
     if (breakStack.numberOfLayers > 0) {
       fringe = Nil
       breakStack.store(node)
@@ -227,7 +227,7 @@ class CfgCreatorForMethod(entryNode: nodes.Method) {
     extendCfg(node)
     // Under normal conditions this is always true.
     // But if the parser missed a loop statement, continueStack
-    // might by empty.
+    // might be empty.
     if (continueStack.numberOfLayers > 0) {
       fringe = Nil
       continueStack.store(node)

--- a/src/main/scala/io/shiftleft/fuzzyc2cpg/passes/CfgCreationPass.scala
+++ b/src/main/scala/io/shiftleft/fuzzyc2cpg/passes/CfgCreationPass.scala
@@ -69,12 +69,10 @@ class CfgCreatorForMethod(entryNode: nodes.Method) {
   private var markerStack = List[Option[nodes.CfgNode]]()
   private case class FringeElement(node: nodes.CfgNode, cfgEdgeType: CfgEdgeType)
   private var labeledNodes = Map[String, nodes.CfgNode]()
-  private var pendingGotoLabels = List[String]()
-  private var pendingCaseLabels = List[String]()
   private var returns = List[nodes.CfgNode]()
   private val breakStack = new LayeredStack[nodes.CfgNode]()
   private val continueStack = new LayeredStack[nodes.CfgNode]()
-  private val caseStack = new LayeredStack[(nodes.CfgNode, Boolean)]()
+  private val caseStack = new LayeredStack[nodes.CfgNode]()
   private var gotos = List[(nodes.CfgNode, String)]()
 
   def run(): Iterator[DiffGraph] = {
@@ -166,10 +164,16 @@ class CfgCreatorForMethod(entryNode: nodes.Method) {
   private def handleJumpTarget(n: nodes.JumpTarget): Unit = {
     val labelName = n.name
     if (labelName.startsWith("case") || labelName.startsWith("default")) {
-      pendingCaseLabels = labelName :: pendingCaseLabels
+      // Under normal conditions this is always true.
+      // But if the parser missed a switch statement, caseStack
+      // might by empty.
+      if (caseStack.numberOfLayers > 0) {
+        caseStack.store(n)
+      }
     } else {
-      pendingGotoLabels = labelName :: pendingGotoLabels
+      labeledNodes = labeledNodes + (labelName -> n)
     }
+    extendCfg(n)
   }
 
   private def handleConditionalExpression(call: nodes.Call): Unit = {
@@ -366,15 +370,13 @@ class CfgCreatorForMethod(entryNode: nodes.Method) {
     node.start.whenTrue.foreach(postOrderLeftToRightExpand)
     val switchFringe = fringe
 
-    caseStack.getTopElements.foreach {
-      case (caseNode, _) =>
-        fringe = conditionFringe
-        extendCfg(caseNode)
+    caseStack.getTopElements.foreach { caseNode =>
+      fringe = conditionFringe
+      extendCfg(caseNode)
     }
 
-    val hasDefaultCase = caseStack.getTopElements.exists {
-      case (_, isDefault) =>
-        isDefault
+    val hasDefaultCase = caseStack.getTopElements.exists { caseNode =>
+      caseNode.asInstanceOf[nodes.JumpTarget].name == "default"
     }
 
     fringe = switchFringe.add(breakStack.getTopElements, AlwaysEdge)
@@ -434,25 +436,6 @@ class CfgCreatorForMethod(entryNode: nodes.Method) {
       val leadingNoneLength = markerStack.segmentLength(_.isEmpty, 0)
       markerStack = List.fill(leadingNoneLength)(Some(dstNode)) ++ markerStack
         .drop(leadingNoneLength)
-    }
-
-    if (pendingGotoLabels.nonEmpty) {
-      pendingGotoLabels.foreach { label =>
-        labeledNodes = labeledNodes + (label -> dstNode)
-      }
-      pendingGotoLabels = List()
-    }
-
-    // TODO at the moment we discard the case labels
-    if (pendingCaseLabels.nonEmpty) {
-      // Under normal conditions this is always true.
-      // But if the parser missed a switch statement, caseStack
-      // might by empty.
-      if (caseStack.numberOfLayers > 0) {
-        val containsDefaultLabel = pendingCaseLabels.contains("default")
-        caseStack.store((dstNode, containsDefaultLabel))
-      }
-      pendingCaseLabels = List()
     }
   }
 

--- a/src/test/scala/io/shiftleft/fuzzyc2cpg/passes/CfgCreationPassTests.scala
+++ b/src/test/scala/io/shiftleft/fuzzyc2cpg/passes/CfgCreationPassTests.scala
@@ -183,6 +183,14 @@ class CfgCreationPassTests extends WordSpec with Matchers {
         succOf("y") shouldBe expected(("x", TrueEdge), ("z", FalseEdge))
         succOf("z") shouldBe expected(("x", TrueEdge), ("RET", FalseEdge))
       }
+
+    "be correct for do-while-loop with empty body" in
+      new CfgFixture("do { } while(x > 1);") {
+        succOf("func ()") shouldBe expected(("x", AlwaysEdge))
+        succOf("1") shouldBe expected(("x > 1", AlwaysEdge))
+        succOf("x > 1") shouldBe expected(("x", TrueEdge), ("RET", FalseEdge))
+      }
+
   }
 
   "Cfg for for-loop" should {
@@ -300,24 +308,28 @@ class CfgCreationPassTests extends WordSpec with Matchers {
       new CfgFixture("x; goto l1; y; l1:") {
         succOf("func ()") shouldBe expected(("x", AlwaysEdge))
         succOf("x") shouldBe expected(("goto l1;", AlwaysEdge))
-        succOf("goto l1;") shouldBe expected(("RET", AlwaysEdge))
-        succOf("y") shouldBe expected(("RET", AlwaysEdge))
+        succOf("goto l1;") shouldBe expected(("l1:", AlwaysEdge))
+        succOf("l1:") shouldBe expected(("RET", AlwaysEdge))
+        succOf("y") shouldBe expected(("l1:", AlwaysEdge))
       }
 
     "be correct for multiple labels" in
       new CfgFixture("x;goto l1; l2: y; l1:") {
         succOf("func ()") shouldBe expected(("x", AlwaysEdge))
         succOf("x") shouldBe expected(("goto l1;", AlwaysEdge))
-        succOf("goto l1;") shouldBe expected(("RET", AlwaysEdge))
-        succOf("y") shouldBe expected(("RET", AlwaysEdge))
+        succOf("goto l1;") shouldBe expected(("l1:", AlwaysEdge))
+        succOf("y") shouldBe expected(("l1:", AlwaysEdge))
+        succOf("l1:") shouldBe expected(("RET", AlwaysEdge))
       }
 
     "be correct for multiple labels on same spot" in
       new CfgFixture("x;goto l2;y;l1:l2:") {
         succOf("func ()") shouldBe expected(("x", AlwaysEdge))
         succOf("x") shouldBe expected(("goto l2;", AlwaysEdge))
-        succOf("goto l2;") shouldBe expected(("RET", AlwaysEdge))
-        succOf("y") shouldBe expected(("RET", AlwaysEdge))
+        succOf("goto l2;") shouldBe expected(("l2:", AlwaysEdge))
+        succOf("y") shouldBe expected(("l1:", AlwaysEdge))
+        succOf("l1:") shouldBe expected(("l2:", AlwaysEdge))
+        succOf("l2:") shouldBe expected(("RET", AlwaysEdge))
       }
   }
 
@@ -325,54 +337,69 @@ class CfgCreationPassTests extends WordSpec with Matchers {
     "be correct with one case" in
       new CfgFixture("switch (x) { case 1: y; }") {
         succOf("func ()") shouldBe expected(("x", AlwaysEdge))
-        succOf("x") shouldBe expected(("y", CaseEdge), ("RET", CaseEdge))
+        succOf("x") shouldBe expected(("case 1:", CaseEdge), ("RET", CaseEdge))
+        succOf("case 1:") shouldBe expected(("y", AlwaysEdge))
         succOf("y") shouldBe expected(("RET", AlwaysEdge))
       }
 
     "be correct with multiple cases" in
       new CfgFixture("switch (x) { case 1: y; case 2: z;}") {
         succOf("func ()") shouldBe expected(("x", AlwaysEdge))
-        succOf("x") shouldBe expected(("y", CaseEdge), ("z", CaseEdge), ("RET", CaseEdge))
-        succOf("y") shouldBe expected(("z", AlwaysEdge))
+        succOf("x") shouldBe expected(("case 1:", CaseEdge), ("case 2:", CaseEdge), ("RET", CaseEdge))
+        succOf("case 1:") shouldBe expected(("y", AlwaysEdge))
+        succOf("y") shouldBe expected(("case 2:", AlwaysEdge))
+        succOf("case 2:") shouldBe expected(("z", AlwaysEdge))
         succOf("z") shouldBe expected(("RET", AlwaysEdge))
       }
 
     "be correct with multiple cases on same spot" in
       new CfgFixture("switch (x) { case 1: case 2: y; }") {
         succOf("func ()") shouldBe expected(("x", AlwaysEdge))
-        succOf("x") shouldBe expected(("y", CaseEdge), ("RET", CaseEdge))
+        succOf("x") shouldBe expected(("case 1:", CaseEdge), ("case 2:", CaseEdge), ("RET", CaseEdge))
+        succOf("case 1:") shouldBe expected(("case 2:", AlwaysEdge))
         succOf("y") shouldBe expected(("RET", AlwaysEdge))
       }
 
     "be correct with multiple cases and multiple cases on same spot" in
       new CfgFixture("switch (x) { case 1: case 2: y; case 3: z;}") {
         succOf("func ()") shouldBe expected(("x", AlwaysEdge))
-        succOf("x") shouldBe expected(("y", CaseEdge), ("z", CaseEdge), ("RET", CaseEdge))
-        succOf("y") shouldBe expected(("z", AlwaysEdge))
+        succOf("x") shouldBe expected(("case 1:", CaseEdge),
+                                      ("case 2:", CaseEdge),
+                                      ("case 3:", CaseEdge),
+                                      ("RET", CaseEdge))
+        succOf("case 1:") shouldBe expected(("case 2:", AlwaysEdge))
+        succOf("case 2:") shouldBe expected(("y", AlwaysEdge))
+        succOf("y") shouldBe expected(("case 3:", AlwaysEdge))
+        succOf("case 3:") shouldBe expected(("z", AlwaysEdge))
         succOf("z") shouldBe expected(("RET", AlwaysEdge))
       }
 
     "be correct with default case" in
       new CfgFixture("switch (x) { default: y; }") {
         succOf("func ()") shouldBe expected(("x", AlwaysEdge))
-        succOf("x") shouldBe expected(("y", CaseEdge))
+        succOf("x") shouldBe expected(("default:", CaseEdge))
+        succOf("default:") shouldBe expected(("y", AlwaysEdge))
         succOf("y") shouldBe expected(("RET", AlwaysEdge))
       }
 
     "be correct for case and default combined" in
       new CfgFixture("switch (x) { case 1: y; break; default: z;}") {
         succOf("func ()") shouldBe expected(("x", AlwaysEdge))
-        succOf("x") shouldBe expected(("y", CaseEdge), ("z", CaseEdge))
+        succOf("x") shouldBe expected(("case 1:", CaseEdge), ("default:", CaseEdge))
+        succOf("case 1:") shouldBe expected(("y", AlwaysEdge))
         succOf("y") shouldBe expected(("break;", AlwaysEdge))
         succOf("break;") shouldBe expected(("RET", AlwaysEdge))
+        succOf("default:") shouldBe expected(("z", AlwaysEdge))
         succOf("z") shouldBe expected(("RET", AlwaysEdge))
       }
 
     "be correct for nested switch" in
-      new CfgFixture("switch (x) { default: switch(y) { default: z; } }") {
+      new CfgFixture("switch (x) { case 1: switch(y) { default: z; } }") {
         succOf("func ()") shouldBe expected(("x", AlwaysEdge))
-        succOf("x") shouldBe expected(("y", CaseEdge))
-        succOf("y") shouldBe expected(("z", CaseEdge))
+        succOf("x") shouldBe expected(("case 1:", CaseEdge), ("RET", CaseEdge))
+        succOf("case 1:") shouldBe expected(("y", AlwaysEdge))
+        succOf("y") shouldBe expected(("default:", CaseEdge))
+        succOf("default:") shouldBe expected(("z", AlwaysEdge))
         succOf("z") shouldBe expected(("RET", AlwaysEdge))
       }
   }


### PR DESCRIPTION
Previously, outgoing CFG edges from `goto $label` statements were connected to the statements directly following the $label. For a few months now, we have made labels explicit in the AST as nodes of type `JUMP_TARGET` (as `label()` and thus `LABEL` is reserved), and these jump targets were already marked as CFG nodes but not yet included in the CFG. This PR changes that, bringing labels into the CFG and connecting them via incoming CFG edges to their gotos. This slightly simplifies CFG generation code, making it possible to drop `pendingGotoLabels` and `pendingCaseLabels`.