### PR TITLE
Use newest `codepropertygraph`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ organization := "io.shiftleft"
 scalaVersion := "2.13.1"
 enablePlugins(GitVersioning)
 
-val cpgVersion = "0.11.334"
+val cpgVersion = "0.11.349"
 val antlrVersion = "4.7.2"
 
 libraryDependencies ++= Seq(


### PR DESCRIPTION
Brings in CONTAINS-node changes by @bbrehm . Looking good so far, still doing one long run on the kernel.